### PR TITLE
Mock an arbitrary number of users more easily

### DIFF
--- a/imports/startup/server/fixtures.js
+++ b/imports/startup/server/fixtures.js
@@ -306,7 +306,7 @@ function generateAffinities(userIds, groupId) {
         helperId: me,
         helpeeId: them,
         groupId: groupId,
-        value: affinityVals[Math.floor(Math.random()*affinityVals.length)]
+        value: _.sample(affinityVals)
       }
     })
   });


### PR DESCRIPTION
Mock an arbitrary number of users more easily in fixtures, rather than just the few who were hard-coded.

Potentially less relevant now that the bug causing that server issue has been identified (we wanted to try replicating), but functionality might be useful in the future?