### PR TITLE
fix(groups): resolve pairing and member management bugs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,7 +23,7 @@ identifiers:
   - type: doi
     value: 10.1145/2531602.2531703
     description: ACM CSCW '14 Proceedings
-repository-code: 'https://github.com/NUDelta/pair-research-meteor'
+repository-code: 'https://github.com/NUDelta/pair-research'
 abstract: >-
   To increase productivity, informal learning, and
   collaborations within and across research groups, we have

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,4 +66,9 @@ export default antfu({
     'perfectionist/sort-named-imports': 'off',
     'perfectionist/sort-named-exports': 'off',
   },
+}, {
+  files: ['src/**/*.test.{ts,tsx}'],
+  rules: {
+    'ts/no-unsafe-assignment': 'off',
+  },
 })

--- a/src/features/groups/components/GroupCard.tsx
+++ b/src/features/groups/components/GroupCard.tsx
@@ -118,7 +118,7 @@ const GroupCard = ({
                     event_.stopPropagation()
                     onAccept()
                   }}
-                  className="hover-lift-sm hover:shadow-lg hover:bg-accent hover:text-accent-foreground"
+                  className="hover-lift-sm hover:shadow-lg hover:bg-green-400 hover:text-accent-foreground"
                 >
                   {isAccepting
                     ? (

--- a/src/features/groups/components/detail/ActiveRoundPanel.tsx
+++ b/src/features/groups/components/detail/ActiveRoundPanel.tsx
@@ -176,12 +176,12 @@ export default function ActiveRoundPanel({
             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               Pairs this round
             </p>
-            <div className="grid gap-3 md:grid-cols-2">
+            <div className="grid items-start gap-3 md:grid-cols-2">
               {orderedPairSummaries.map((pairSummary) => {
                 return (
                   <div
                     key={pairSummary.id}
-                    className="rounded-xl border bg-background/90 p-4 shadow-sm hover-lift-sm hover:shadow-md"
+                    className="relative z-0 rounded-xl border bg-background/90 p-4 shadow-sm hover-lift-sm hover:z-20 hover:shadow-md focus-within:z-20"
                   >
                     <div className="flex flex-col items-center gap-4 sm:grid sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] sm:items-center">
                       <div className="flex justify-center sm:justify-end">

--- a/src/features/groups/components/detail/SingleGroupPageContent.test.tsx
+++ b/src/features/groups/components/detail/SingleGroupPageContent.test.tsx
@@ -21,9 +21,55 @@ const {
   mockPairingProps: vi.fn(),
 }))
 
+function MockLink({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}
+
+function MockGroupDetailHeader(props: {
+  actions?: ReactNode
+  roundStatusLabel?: string
+  roundStatusNote?: string | null
+}) {
+  mockGroupDetailHeaderProps(props)
+
+  return (
+    <div data-testid="group-detail-header">
+      <span>{props.roundStatusLabel}</span>
+      <span>{props.roundStatusNote}</span>
+      {props.actions}
+    </div>
+  )
+}
+
+function MockTaskCard(props: unknown) {
+  mockTaskCardProps(props)
+  return <div data-testid="task-card">Task Card</div>
+}
+
+function MockPairing(props: unknown) {
+  mockPairingProps(props)
+  return <div data-testid="pairing-card">Current Pairing</div>
+}
+
+function MockOthersTasks(props: unknown) {
+  mockOthersTasksProps(props)
+  return <div data-testid="others-tasks">Others Tasks</div>
+}
+
+function MockLeavePoolButton() {
+  return <button type="button">Leave Pool</button>
+}
+
+function MockMakePairsButton() {
+  return <button type="button">Make Pairs</button>
+}
+
+function MockResetPoolButton() {
+  return <button type="button">Reset Pool</button>
+}
+
 vi.mock('@tanstack/react-router', () => ({
-  // eslint-disable-next-line react/component-hook-factories
-  Link: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Link: MockLink,
 }))
 
 vi.mock('@/features/groups/hooks/useTaskRealtimeListener', () => ({
@@ -43,46 +89,19 @@ vi.mock('@/features/groups/components/detail/roundStatus', () => ({
 }))
 
 vi.mock('@/features/groups/components/detail/GroupDetailHeader', () => ({
-
-  default: (props: {
-    actions?: ReactNode
-    roundStatusLabel?: string
-    roundStatusNote?: string | null
-  }) => {
-    mockGroupDetailHeaderProps(props)
-
-    return (
-      <div data-testid="group-detail-header">
-        <span>{props.roundStatusLabel}</span>
-        <span>{props.roundStatusNote}</span>
-        {props.actions}
-      </div>
-    )
-  },
+  default: MockGroupDetailHeader,
 }))
 
 vi.mock('@/features/groups/components/detail/TaskCard', () => ({
-
-  default: (props: unknown) => {
-    mockTaskCardProps(props)
-    return <div data-testid="task-card">Task Card</div>
-  },
+  default: MockTaskCard,
 }))
 
 vi.mock('@/features/groups/components/detail/Pairing', () => ({
-
-  default: (props: unknown) => {
-    mockPairingProps(props)
-    return <div data-testid="pairing-card">Current Pairing</div>
-  },
+  default: MockPairing,
 }))
 
 vi.mock('@/features/groups/components/detail/OthersTasks', () => ({
-
-  default: (props: unknown) => {
-    mockOthersTasksProps(props)
-    return <div data-testid="others-tasks">Others Tasks</div>
-  },
+  default: MockOthersTasks,
 }))
 
 vi.mock('@/features/groups/components/detail/PairingSuccessConfetti', () => ({
@@ -90,12 +109,9 @@ vi.mock('@/features/groups/components/detail/PairingSuccessConfetti', () => ({
 }))
 
 vi.mock('@/features/groups/components/detail/buttons', () => ({
-  // eslint-disable-next-line react/component-hook-factories
-  LeavePoolButton: () => <button type="button">Leave Pool</button>,
-  // eslint-disable-next-line react/component-hook-factories
-  MakePairsButton: () => <button type="button">Make Pairs</button>,
-  // eslint-disable-next-line react/component-hook-factories
-  ResetPoolButton: () => <button type="button">Reset Pool</button>,
+  LeavePoolButton: MockLeavePoolButton,
+  MakePairsButton: MockMakePairsButton,
+  ResetPoolButton: MockResetPoolButton,
 }))
 
 const baseTask: Task = {

--- a/src/features/groups/components/detail/SingleGroupPageContent.tsx
+++ b/src/features/groups/components/detail/SingleGroupPageContent.tsx
@@ -58,9 +58,6 @@ export default function SingleGroupPageContent({
     = groupInfo.hasActivePairing
       && currentUserActivePairingTaskWithProfile === null
       && currentUserTask !== undefined
-  const totalRatingsNeededPerTask = Math.max(tasks.length - 1, 0)
-  const allRatingsSubmitted = tasks.length >= 2
-    && tasks.every(task => (task.ratingsCompletedCount ?? 0) >= totalRatingsNeededPerTask)
   const activeRoundRelativeTime = groupInfo.activePairingCreatedAt === null
     ? null
     : formatPairingRelativeTime(groupInfo.activePairingCreatedAt)
@@ -121,7 +118,6 @@ export default function SingleGroupPageContent({
                     <MakePairsButton
                       groupId={groupInfo.id}
                       eligibleTaskCount={tasks.length}
-                      allRatingsSubmitted={allRatingsSubmitted}
                     />
                   )}
                 </>

--- a/src/features/groups/components/detail/buttons/MakePairsButton.tsx
+++ b/src/features/groups/components/detail/buttons/MakePairsButton.tsx
@@ -9,58 +9,28 @@ import { Button } from '@/shared/ui/button'
 interface Props {
   groupId: string
   eligibleTaskCount: number
-  allRatingsSubmitted: boolean
 }
 
-const MakePairsButton = ({ groupId, eligibleTaskCount, allRatingsSubmitted }: Props) => {
+const MakePairsButton = ({ groupId, eligibleTaskCount }: Props) => {
   const [isPending, startTransition] = useTransition()
   const router = useRouter()
   const makePairsFn = useServerFn(makePairs)
-  const isDisabled = eligibleTaskCount < 2 || !allRatingsSubmitted || isPending
+  const isDisabled = eligibleTaskCount < 2 || isPending
   const disabledReason = eligibleTaskCount === 0
     ? 'The pool is empty. At least two active tasks are required to make pairs.'
     : eligibleTaskCount < 2
       ? 'At least two active tasks are required to make pairs.'
-      : 'Everyone in the pool must finish rating every other task before making pairs.'
+      : undefined
 
-  const handleMakePairs = async (force = false) => {
+  const handleMakePairs = async () => {
     startTransition(async () => {
-      const response = await makePairsFn({ data: { groupId, force } })
+      const response = await makePairsFn({ data: { groupId } })
       if (response.success) {
         toast.success(response.message)
         await router.invalidate()
       }
       else {
-        if (response.data?.missingHelpCapacities) {
-          // Show missing help capacities in the confirmation dialog
-          const missingCount = response.data.missingHelpCapacities.length
-          const missingDetails = response.data.missingHelpCapacities
-            .map(m => `${m.userName} hasn't set help capacity for "${m.taskDescription}"`)
-            .join('\n')
-
-          toast.error(
-            <div>
-              <p>
-                There are
-                {missingCount}
-                {' '}
-                missing help capacities:
-              </p>
-              <pre className="mt-2 whitespace-pre-wrap text-sm">{missingDetails}</pre>
-              <p className="mt-2">Do you want to proceed anyway?</p>
-            </div>,
-            {
-              duration: 10000,
-              action: {
-                label: 'Proceed',
-                onClick: async () => handleMakePairs(true),
-              },
-            },
-          )
-        }
-        else {
-          toast.error(response.message)
-        }
+        toast.error(response.message)
       }
     })
   }

--- a/src/features/groups/components/detail/groupsDetail.test.tsx
+++ b/src/features/groups/components/detail/groupsDetail.test.tsx
@@ -56,7 +56,7 @@ describe('groups detail controls', () => {
   })
 
   it('disables make pairs when fewer than two pool tasks are available', () => {
-    render(<MakePairsButton groupId="group-1" eligibleTaskCount={0} allRatingsSubmitted={false} />)
+    render(<MakePairsButton groupId="group-1" eligibleTaskCount={0} />)
 
     expect(screen.getByRole('button', { name: 'Make Pairs' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Make Pairs' })).toHaveAttribute(
@@ -65,14 +65,11 @@ describe('groups detail controls', () => {
     )
   })
 
-  it('disables make pairs until every pool member has submitted all ratings', () => {
-    render(<MakePairsButton groupId="group-1" eligibleTaskCount={3} allRatingsSubmitted={false} />)
+  it('keeps make pairs available when some ratings are still missing', () => {
+    render(<MakePairsButton groupId="group-1" eligibleTaskCount={3} />)
 
-    expect(screen.getByRole('button', { name: 'Make Pairs' })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'Make Pairs' })).toHaveAttribute(
-      'title',
-      'Everyone in the pool must finish rating every other task before making pairs.',
-    )
+    expect(screen.getByRole('button', { name: 'Make Pairs' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Make Pairs' })).not.toHaveAttribute('title')
   })
 
   it('keeps reset pool available for admins via confirmation dialog', () => {

--- a/src/features/groups/components/settings/members/AddGroupMemberDialog.test.tsx
+++ b/src/features/groups/components/settings/members/AddGroupMemberDialog.test.tsx
@@ -3,53 +3,87 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import AddGroupMemberDialog from './AddGroupMemberDialog'
 
-const mockUseGroupMemberInviteDialog = vi.fn(() => ({
-  defaultIsAdmin: false,
-  defaultRoleId: 'role-1',
-  draftSource: '',
-  fileInputRef: { current: null },
-  handleAddBlankRow: vi.fn(),
-  handleApplyAssignment: vi.fn(),
-  handleCancel: vi.fn(),
-  handleDialogToggle: vi.fn(),
-  handleFileChange: vi.fn(),
-  handleImportSource: vi.fn(),
-  handleRemoveRow: vi.fn(),
-  handleSubmit: vi.fn(),
-  handleUpdateRow: vi.fn(),
-  hasAdminInvite: false,
-  inviteRows: [],
-  isPending: false,
-  open: true,
-  rowErrors: {},
-  selectedRowIdSet: new Set<string>(),
-  selectedRowIds: [],
-  setDefaultIsAdmin: vi.fn(),
-  setDefaultRoleId: vi.fn(),
-  setDraftSource: vi.fn(),
-  setSelectedRowIds: vi.fn(),
-  toggleRowSelection: vi.fn(),
+const { mockUseGroupMemberInviteDialog } = vi.hoisted(() => ({
+  mockUseGroupMemberInviteDialog: vi.fn(() => ({
+    defaultIsAdmin: false,
+    defaultRoleId: 'role-1',
+    draftSource: '',
+    fileInputRef: { current: null },
+    handleAddBlankRow: vi.fn(),
+    handleApplyAssignment: vi.fn(),
+    handleCancel: vi.fn(),
+    handleDialogToggle: vi.fn(),
+    handleFileChange: vi.fn(),
+    handleImportSource: vi.fn(),
+    handleRemoveRow: vi.fn(),
+    handleSubmit: vi.fn(),
+    handleUpdateRow: vi.fn(),
+    hasAdminInvite: false,
+    inviteRows: [],
+    isPending: false,
+    open: true,
+    rowErrors: {},
+    selectedRowIdSet: new Set<string>(),
+    selectedRowIds: [],
+    setDefaultIsAdmin: vi.fn(),
+    setDefaultRoleId: vi.fn(),
+    setDraftSource: vi.fn(),
+    setSelectedRowIds: vi.fn(),
+    toggleRowSelection: vi.fn(),
+  })),
 }))
+
+function MockMemberInviteBatchEditor() {
+  return <div data-testid="member-invite-batch-editor">Batch editor</div>
+}
+
+function MockDialog({ children }: PropsWithChildren) {
+  return <div>{children}</div>
+}
+
+function MockDialogContent({ children, className }: PropsWithChildren<{ className?: string }>) {
+  return <div className={className}>{children}</div>
+}
+
+function MockDialogDescription({ children }: PropsWithChildren) {
+  return <div>{children}</div>
+}
+
+function MockDialogFooter({ children, className }: PropsWithChildren<{ className?: string }>) {
+  return <div className={className}>{children}</div>
+}
+
+function MockDialogHeader({ children }: PropsWithChildren) {
+  return <div>{children}</div>
+}
+
+function MockDialogTitle({ children }: PropsWithChildren) {
+  return <div>{children}</div>
+}
+
+function MockDialogTrigger({ children }: PropsWithChildren) {
+  return <div>{children}</div>
+}
 
 vi.mock('./useGroupMemberInviteDialog', () => ({
   useGroupMemberInviteDialog: mockUseGroupMemberInviteDialog,
 }))
 
 vi.mock('./MemberInviteBatchEditor', () => ({
-  default: () => <div data-testid="member-invite-batch-editor">Batch editor</div>,
+  default: MockMemberInviteBatchEditor,
 }))
 
 vi.mock('@/shared/ui/dialog', () => ({
-  Dialog: ({ children }: PropsWithChildren) => <div>{children}</div>,
-  DialogContent: ({ children, className }: PropsWithChildren<{ className?: string }>) => <div className={className}>{children}</div>,
-  DialogDescription: ({ children }: PropsWithChildren) => <div>{children}</div>,
-  DialogFooter: ({ children, className }: PropsWithChildren<{ className?: string }>) => <div className={className}>{children}</div>,
-  DialogHeader: ({ children }: PropsWithChildren) => <div>{children}</div>,
-  DialogTitle: ({ children }: PropsWithChildren) => <div>{children}</div>,
-  DialogTrigger: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  Dialog: MockDialog,
+  DialogContent: MockDialogContent,
+  DialogDescription: MockDialogDescription,
+  DialogFooter: MockDialogFooter,
+  DialogHeader: MockDialogHeader,
+  DialogTitle: MockDialogTitle,
+  DialogTrigger: MockDialogTrigger,
 }))
 
-describe('AddGroupMemberDialog', () => {
+describe('addGroupMemberDialog', () => {
   it('keeps the add-members dialog content inside a scrollable region', () => {
     render(
       <AddGroupMemberDialog
@@ -65,6 +99,7 @@ describe('AddGroupMemberDialog', () => {
     expect(scrollRegion).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto', 'overscroll-contain')
     expect(screen.getByTestId('member-invite-batch-editor')).toBeInTheDocument()
     expect(mockUseGroupMemberInviteDialog).toHaveBeenCalledWith({
+      existingMemberEmails: [],
       groupId: 'group-1',
       roles: [{ id: 'role-1', title: 'Researcher' }],
     })

--- a/src/features/groups/components/settings/members/AddGroupMemberDialog.test.tsx
+++ b/src/features/groups/components/settings/members/AddGroupMemberDialog.test.tsx
@@ -1,0 +1,72 @@
+import type { PropsWithChildren } from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import AddGroupMemberDialog from './AddGroupMemberDialog'
+
+const mockUseGroupMemberInviteDialog = vi.fn(() => ({
+  defaultIsAdmin: false,
+  defaultRoleId: 'role-1',
+  draftSource: '',
+  fileInputRef: { current: null },
+  handleAddBlankRow: vi.fn(),
+  handleApplyAssignment: vi.fn(),
+  handleCancel: vi.fn(),
+  handleDialogToggle: vi.fn(),
+  handleFileChange: vi.fn(),
+  handleImportSource: vi.fn(),
+  handleRemoveRow: vi.fn(),
+  handleSubmit: vi.fn(),
+  handleUpdateRow: vi.fn(),
+  hasAdminInvite: false,
+  inviteRows: [],
+  isPending: false,
+  open: true,
+  rowErrors: {},
+  selectedRowIdSet: new Set<string>(),
+  selectedRowIds: [],
+  setDefaultIsAdmin: vi.fn(),
+  setDefaultRoleId: vi.fn(),
+  setDraftSource: vi.fn(),
+  setSelectedRowIds: vi.fn(),
+  toggleRowSelection: vi.fn(),
+}))
+
+vi.mock('./useGroupMemberInviteDialog', () => ({
+  useGroupMemberInviteDialog: mockUseGroupMemberInviteDialog,
+}))
+
+vi.mock('./MemberInviteBatchEditor', () => ({
+  default: () => <div data-testid="member-invite-batch-editor">Batch editor</div>,
+}))
+
+vi.mock('@/shared/ui/dialog', () => ({
+  Dialog: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogContent: ({ children, className }: PropsWithChildren<{ className?: string }>) => <div className={className}>{children}</div>,
+  DialogDescription: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogFooter: ({ children, className }: PropsWithChildren<{ className?: string }>) => <div className={className}>{children}</div>,
+  DialogHeader: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogTitle: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  DialogTrigger: ({ children }: PropsWithChildren) => <div>{children}</div>,
+}))
+
+describe('AddGroupMemberDialog', () => {
+  it('keeps the add-members dialog content inside a scrollable region', () => {
+    render(
+      <AddGroupMemberDialog
+        groupId="group-1"
+        roles={[{ id: 'role-1', title: 'Researcher' }]}
+      />,
+    )
+
+    const scrollRegion = screen.getByTestId('add-members-dialog-scroll-region')
+    const dialogContent = scrollRegion.parentElement?.parentElement
+
+    expect(dialogContent).toHaveClass('max-h-[90vh]', 'overflow-hidden')
+    expect(scrollRegion).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto', 'overscroll-contain')
+    expect(screen.getByTestId('member-invite-batch-editor')).toBeInTheDocument()
+    expect(mockUseGroupMemberInviteDialog).toHaveBeenCalledWith({
+      groupId: 'group-1',
+      roles: [{ id: 'role-1', title: 'Researcher' }],
+    })
+  })
+})

--- a/src/features/groups/components/settings/members/AddGroupMemberDialog.tsx
+++ b/src/features/groups/components/settings/members/AddGroupMemberDialog.tsx
@@ -8,12 +8,14 @@ import MemberInviteBatchEditor from './MemberInviteBatchEditor'
 import { useGroupMemberInviteDialog } from './useGroupMemberInviteDialog'
 
 interface AddGroupMemberDialogProps {
+  existingMemberEmails?: string[]
   groupId: string
   roles: GroupSettingsRole[]
   triggerClassName?: string
 }
 
 export default function AddGroupMemberDialog({
+  existingMemberEmails = [],
   groupId,
   roles,
   triggerClassName,
@@ -44,7 +46,7 @@ export default function AddGroupMemberDialog({
     setDraftSource,
     setSelectedRowIds,
     toggleRowSelection,
-  } = useGroupMemberInviteDialog({ groupId, roles })
+  } = useGroupMemberInviteDialog({ existingMemberEmails, groupId, roles })
 
   return (
     <Dialog open={open} onOpenChange={handleDialogToggle}>
@@ -54,67 +56,74 @@ export default function AddGroupMemberDialog({
           Add members
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-4xl">
-        <DialogHeader>
-          <DialogTitle>Add members</DialogTitle>
-          <DialogDescription>
-            Prepare up to
-            {' '}
-            {MAX_GROUP_MEMBER_INVITES}
-            {' '}
-            invites from pasted text or CSV, then apply shared or per-member access before sending.
-          </DialogDescription>
-        </DialogHeader>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".csv,text/csv"
-          className="hidden"
-          onChange={event => void handleFileChange(event)}
-        />
-        <MemberInviteBatchEditor
-          defaultIsAdmin={defaultIsAdmin}
-          defaultRoleId={defaultRoleId}
-          draftSource={draftSource}
-          inviteRows={inviteRows}
-          maxInvites={MAX_GROUP_MEMBER_INVITES}
-          onAddBlankRow={handleAddBlankRow}
-          onApplyAssignment={handleApplyAssignment}
-          onDraftSourceChange={setDraftSource}
-          onImportSource={() => handleImportSource(draftSource)}
-          onOpenFilePicker={() => fileInputRef.current?.click()}
-          onRemoveRow={handleRemoveRow}
-          onSelectAllRows={checked => setSelectedRowIds(checked ? inviteRows.map(row => row.id) : [])}
-          onSelectRow={toggleRowSelection}
-          onUpdateDefaultAccess={setDefaultIsAdmin}
-          onUpdateDefaultRole={setDefaultRoleId}
-          onUpdateRow={handleUpdateRow}
-          roles={roles}
-          rowErrors={rowErrors}
-          selectedCount={selectedRowIds.length}
-          selectedRowIds={selectedRowIdSet}
-        />
-        <DialogFooter className="flex-col gap-2 sm:flex-row">
-          <Button variant="outline" onClick={handleCancel} disabled={isPending}>
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            onClick={handleSubmit}
-            disabled={inviteRows.length === 0 || isPending || roles.length === 0}
+      <DialogContent className="flex max-h-[90vh] flex-col overflow-hidden p-0 sm:max-w-4xl">
+        <div className="flex min-h-0 flex-1 flex-col p-6">
+          <DialogHeader>
+            <DialogTitle>Add members</DialogTitle>
+            <DialogDescription>
+              Prepare up to
+              {' '}
+              {MAX_GROUP_MEMBER_INVITES}
+              {' '}
+              invites from pasted text or CSV, then apply shared or per-member access before sending.
+            </DialogDescription>
+          </DialogHeader>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,text/csv"
+            className="hidden"
+            onChange={event => void handleFileChange(event)}
+          />
+          <div
+            data-testid="add-members-dialog-scroll-region"
+            className="min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1"
           >
-            {isPending
-              ? <Spinner text="Adding members..." />
-              : (
-                  <>
-                    {hasAdminInvite
-                      ? <ShieldPlusIcon data-icon="inline-start" />
-                      : <UserPlusIcon data-icon="inline-start" />}
-                    {hasAdminInvite ? 'Add members with access' : 'Add members'}
-                  </>
-                )}
-          </Button>
-        </DialogFooter>
+            <MemberInviteBatchEditor
+              defaultIsAdmin={defaultIsAdmin}
+              defaultRoleId={defaultRoleId}
+              draftSource={draftSource}
+              inviteRows={inviteRows}
+              maxInvites={MAX_GROUP_MEMBER_INVITES}
+              onAddBlankRow={handleAddBlankRow}
+              onApplyAssignment={handleApplyAssignment}
+              onDraftSourceChange={setDraftSource}
+              onImportSource={() => handleImportSource(draftSource)}
+              onOpenFilePicker={() => fileInputRef.current?.click()}
+              onRemoveRow={handleRemoveRow}
+              onSelectAllRows={checked => setSelectedRowIds(checked ? inviteRows.map(row => row.id) : [])}
+              onSelectRow={toggleRowSelection}
+              onUpdateDefaultAccess={setDefaultIsAdmin}
+              onUpdateDefaultRole={setDefaultRoleId}
+              onUpdateRow={handleUpdateRow}
+              roles={roles}
+              rowErrors={rowErrors}
+              selectedCount={selectedRowIds.length}
+              selectedRowIds={selectedRowIdSet}
+            />
+          </div>
+          <DialogFooter className="border-t pt-4">
+            <Button variant="outline" onClick={handleCancel} disabled={isPending}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSubmit}
+              disabled={inviteRows.length === 0 || isPending || roles.length === 0}
+            >
+              {isPending
+                ? <Spinner text="Adding members..." />
+                : (
+                    <>
+                      {hasAdminInvite
+                        ? <ShieldPlusIcon data-icon="inline-start" />
+                        : <UserPlusIcon data-icon="inline-start" />}
+                      {hasAdminInvite ? 'Add members with access' : 'Add members'}
+                    </>
+                  )}
+            </Button>
+          </DialogFooter>
+        </div>
       </DialogContent>
     </Dialog>
   )

--- a/src/features/groups/components/settings/members/GroupMembersTable.test.tsx
+++ b/src/features/groups/components/settings/members/GroupMembersTable.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import GroupMembersTable from './GroupMembersTable'
+
+const mockUseNavigate = vi.fn(() => vi.fn())
+const mockUseRouter = vi.fn(() => ({
+  invalidate: vi.fn(),
+}))
+const mockUseServerFn = vi.fn(() => vi.fn())
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: mockUseNavigate,
+  useRouter: mockUseRouter,
+}))
+
+vi.mock('@tanstack/react-start', () => ({
+  useServerFn: mockUseServerFn,
+}))
+
+vi.mock('@/features/groups/server/groups/bulkUpdateGroupMemberRoles', () => ({
+  bulkUpdateGroupMemberRoles: {},
+}))
+
+vi.mock('@/features/groups/server/groups/removeGroupMember', () => ({
+  removeGroupMember: {},
+}))
+
+vi.mock('@/features/groups/server/groups/updateGroupMember', () => ({
+  updateGroupMember: {},
+}))
+
+vi.mock('@/shared/ui/data-table', () => ({
+  DataTable: () => <div data-testid="members-data-table">Members table</div>,
+}))
+
+describe('GroupMembersTable', () => {
+  it('wraps large member lists in an internal scroll region', () => {
+    render(
+      <GroupMembersTable
+        creatorId="user-1"
+        currentUserId="user-1"
+        groupId="group-1"
+        hasActivePairing
+        members={[
+          {
+            userId: 'user-1',
+            fullName: 'Ada Lovelace',
+            avatarUrl: null,
+            email: 'ada@example.com',
+            roleId: 'role-1',
+            roleTitle: 'Researcher',
+            isAdmin: true,
+            isPending: false,
+            joinedAt: '2026-04-17T12:00:00.000Z',
+            isCreator: true,
+          },
+        ]}
+        roles={[
+          {
+            id: 'role-1',
+            title: 'Researcher',
+          },
+        ]}
+      />,
+    )
+
+    const card = screen.getByText('Members').closest('[data-slot="card"]')
+    const scrollRegion = screen.getByTestId('group-members-scroll-region')
+
+    expect(card).toHaveClass('overflow-hidden')
+    expect(scrollRegion).toHaveClass('max-h-[70vh]', 'overflow-y-auto', 'overscroll-contain')
+    expect(screen.getByText('Active pairing in progress')).toBeInTheDocument()
+    expect(screen.getByTestId('members-data-table')).toBeInTheDocument()
+  })
+})

--- a/src/features/groups/components/settings/members/GroupMembersTable.test.tsx
+++ b/src/features/groups/components/settings/members/GroupMembersTable.test.tsx
@@ -2,11 +2,21 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import GroupMembersTable from './GroupMembersTable'
 
-const mockUseNavigate = vi.fn(() => vi.fn())
-const mockUseRouter = vi.fn(() => ({
-  invalidate: vi.fn(),
+const { mockUseNavigate, mockUseRouter, mockUseServerFn } = vi.hoisted(() => ({
+  mockUseNavigate: vi.fn(() => vi.fn()),
+  mockUseRouter: vi.fn(() => ({
+    invalidate: vi.fn(),
+  })),
+  mockUseServerFn: vi.fn(() => vi.fn()),
 }))
-const mockUseServerFn = vi.fn(() => vi.fn())
+
+function MockDataTable() {
+  return <div data-testid="members-data-table">Members table</div>
+}
+
+function MockGroupMembersToolbar() {
+  return <div data-testid="group-members-toolbar">Toolbar</div>
+}
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: mockUseNavigate,
@@ -30,10 +40,14 @@ vi.mock('@/features/groups/server/groups/updateGroupMember', () => ({
 }))
 
 vi.mock('@/shared/ui/data-table', () => ({
-  DataTable: () => <div data-testid="members-data-table">Members table</div>,
+  DataTable: MockDataTable,
 }))
 
-describe('GroupMembersTable', () => {
+vi.mock('./GroupMembersToolbar', () => ({
+  default: MockGroupMembersToolbar,
+}))
+
+describe('groupMembersTable', () => {
   it('wraps large member lists in an internal scroll region', () => {
     render(
       <GroupMembersTable

--- a/src/features/groups/components/settings/members/GroupMembersTable.tsx
+++ b/src/features/groups/components/settings/members/GroupMembersTable.tsx
@@ -224,6 +224,7 @@ export default function GroupMembersTable({
 
               return (
                 <GroupMembersToolbar
+                  existingMemberEmails={members.map(member => member.email)}
                   groupId={groupId}
                   hasNonRemovableSelected={hasNonRemovableSelected}
                   isBulkRemoving={isBulkRemoving}

--- a/src/features/groups/components/settings/members/GroupMembersTable.tsx
+++ b/src/features/groups/components/settings/members/GroupMembersTable.tsx
@@ -188,7 +188,7 @@ export default function GroupMembersTable({
   )
 
   return (
-    <Card>
+    <Card className="overflow-hidden">
       <CardHeader>
         <div className="flex flex-col gap-1">
           <CardTitle>Members</CardTitle>
@@ -197,96 +197,101 @@ export default function GroupMembersTable({
           </CardDescription>
         </div>
       </CardHeader>
-      <CardContent className="flex flex-col gap-4 px-0 pb-0">
-        {hasActivePairing && (
-          <div className="mx-4 rounded-lg border border-dashed px-4 py-3 sm:mx-6">
-            <p className="font-medium">Active pairing in progress</p>
-            <p className="text-sm text-muted-foreground">
-              Confirmed members stay locked until the pool is reset. Pending invitations can still be removed.
-            </p>
-          </div>
-        )}
-        <DataTable
-          columns={columns}
-          data={data}
-          emptyMessage="No members found for this group."
-          filterColumnId="displayName"
-          filterPlaceholder="Filter members..."
-          getRowId={row => row.userId}
-          renderToolbar={(table) => {
-            const selectedMembers = table.getFilteredSelectedRowModel().rows.map(row => row.original)
-            const selectedRemovableMembers = selectedMembers.filter(member => member.canRemove)
-            const hasNonRemovableSelected = selectedMembers.some(member => !member.canRemove)
+      <CardContent className="px-0 pb-0">
+        <div
+          data-testid="group-members-scroll-region"
+          className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto overscroll-contain"
+        >
+          {hasActivePairing && (
+            <div className="mx-4 rounded-lg border border-dashed px-4 py-3 sm:mx-6">
+              <p className="font-medium">Active pairing in progress</p>
+              <p className="text-sm text-muted-foreground">
+                Confirmed members stay locked until the pool is reset. Pending invitations can still be removed.
+              </p>
+            </div>
+          )}
+          <DataTable
+            columns={columns}
+            data={data}
+            emptyMessage="No members found for this group."
+            filterColumnId="displayName"
+            filterPlaceholder="Filter members..."
+            getRowId={row => row.userId}
+            renderToolbar={(table) => {
+              const selectedMembers = table.getFilteredSelectedRowModel().rows.map(row => row.original)
+              const selectedRemovableMembers = selectedMembers.filter(member => member.canRemove)
+              const hasNonRemovableSelected = selectedMembers.some(member => !member.canRemove)
 
-            return (
-              <GroupMembersToolbar
-                groupId={groupId}
-                hasNonRemovableSelected={hasNonRemovableSelected}
-                isBulkRemoving={isBulkRemoving}
-                isBulkUpdatingRole={isBulkUpdatingRole}
-                onBulkRemove={async () => {
-                  startBulkRemoveTransition(async () => {
-                    let removedCount = 0
-                    const failures: string[] = []
+              return (
+                <GroupMembersToolbar
+                  groupId={groupId}
+                  hasNonRemovableSelected={hasNonRemovableSelected}
+                  isBulkRemoving={isBulkRemoving}
+                  isBulkUpdatingRole={isBulkUpdatingRole}
+                  onBulkRemove={async () => {
+                    startBulkRemoveTransition(async () => {
+                      let removedCount = 0
+                      const failures: string[] = []
 
-                    for (const member of selectedRemovableMembers) {
-                      const response = await removeGroupMemberFn({
+                      for (const member of selectedRemovableMembers) {
+                        const response = await removeGroupMemberFn({
+                          data: {
+                            groupId,
+                            userId: member.userId,
+                          },
+                        })
+
+                        if (response.success) {
+                          removedCount += 1
+                          continue
+                        }
+
+                        failures.push(`${member.displayName}: ${response.message}`)
+                      }
+
+                      table.resetRowSelection()
+                      await router.invalidate()
+
+                      if (removedCount > 0) {
+                        toast.success(`Removed ${removedCount} selected ${removedCount === 1 ? 'member' : 'members'}.`)
+                      }
+
+                      if (failures.length === 1) {
+                        toast.error(failures[0])
+                      }
+                      else if (failures.length > 1) {
+                        toast.error(`${failures.length} selected members could not be removed.`)
+                      }
+                    })
+                  }}
+                  onBulkRoleUpdate={async (roleId) => {
+                    startBulkUpdateRoleTransition(async () => {
+                      const response = await bulkUpdateGroupMemberRolesFn({
                         data: {
                           groupId,
-                          userId: member.userId,
+                          roleId,
+                          userIds: selectedMembers.map(member => member.userId),
                         },
                       })
 
-                      if (response.success) {
-                        removedCount += 1
-                        continue
+                      if (!response.success) {
+                        toast.error(response.message)
+                        return
                       }
 
-                      failures.push(`${member.displayName}: ${response.message}`)
-                    }
-
-                    table.resetRowSelection()
-                    await router.invalidate()
-
-                    if (removedCount > 0) {
-                      toast.success(`Removed ${removedCount} selected ${removedCount === 1 ? 'member' : 'members'}.`)
-                    }
-
-                    if (failures.length === 1) {
-                      toast.error(failures[0])
-                    }
-                    else if (failures.length > 1) {
-                      toast.error(`${failures.length} selected members could not be removed.`)
-                    }
-                  })
-                }}
-                onBulkRoleUpdate={async (roleId) => {
-                  startBulkUpdateRoleTransition(async () => {
-                    const response = await bulkUpdateGroupMemberRolesFn({
-                      data: {
-                        groupId,
-                        roleId,
-                        userIds: selectedMembers.map(member => member.userId),
-                      },
+                      toast.success(response.message)
+                      table.resetRowSelection()
+                      await router.invalidate()
                     })
-
-                    if (!response.success) {
-                      toast.error(response.message)
-                      return
-                    }
-
-                    toast.success(response.message)
-                    table.resetRowSelection()
-                    await router.invalidate()
-                  })
-                }}
-                roles={roles}
-                selectedMembers={selectedMembers}
-                selectedRemovableMembers={selectedRemovableMembers}
-              />
-            )
-          }}
-        />
+                  }}
+                  roles={roles}
+                  selectedMembers={selectedMembers}
+                  selectedRemovableMembers={selectedRemovableMembers}
+                />
+              )
+            }}
+          />
+        </div>
       </CardContent>
     </Card>
   )

--- a/src/features/groups/components/settings/members/GroupMembersToolbar.tsx
+++ b/src/features/groups/components/settings/members/GroupMembersToolbar.tsx
@@ -17,6 +17,7 @@ import {
 import AddGroupMemberDialog from './AddGroupMemberDialog'
 
 interface GroupMembersToolbarProps {
+  existingMemberEmails: string[]
   groupId: string
   hasNonRemovableSelected: boolean
   isBulkRemoving: boolean
@@ -29,6 +30,7 @@ interface GroupMembersToolbarProps {
 }
 
 export default function GroupMembersToolbar({
+  existingMemberEmails,
   groupId,
   hasNonRemovableSelected,
   isBulkRemoving,
@@ -102,7 +104,12 @@ export default function GroupMembersToolbar({
             </DropdownMenuGroup>
           </DropdownMenuContent>
         </DropdownMenu>
-        <AddGroupMemberDialog groupId={groupId} roles={roles} triggerClassName="flex-1 sm:flex-none" />
+        <AddGroupMemberDialog
+          existingMemberEmails={existingMemberEmails}
+          groupId={groupId}
+          roles={roles}
+          triggerClassName="flex-1 sm:flex-none"
+        />
       </div>
     </>
   )

--- a/src/features/groups/components/settings/members/memberInviteRowState.ts
+++ b/src/features/groups/components/settings/members/memberInviteRowState.ts
@@ -33,6 +33,7 @@ export function applySharedAssignmentToInviteRows(
 export function buildImportSummaryMessage(summary: {
   addedCount: number
   duplicateCount: number
+  existingMemberCount: number
   invalidCount: number
   unresolvedRoleCount: number
   truncatedCount: number
@@ -41,6 +42,10 @@ export function buildImportSummaryMessage(summary: {
 
   if (summary.duplicateCount > 0) {
     segments.push(`Skipped ${summary.duplicateCount} duplicate ${summary.duplicateCount === 1 ? 'entry' : 'entries'}.`)
+  }
+
+  if (summary.existingMemberCount > 0) {
+    segments.push(`Skipped ${summary.existingMemberCount} ${summary.existingMemberCount === 1 ? 'member' : 'members'} already in the group.`)
   }
 
   if (summary.invalidCount > 0) {

--- a/src/features/groups/components/settings/members/useGroupMemberInviteDialog.test.tsx
+++ b/src/features/groups/components/settings/members/useGroupMemberInviteDialog.test.tsx
@@ -1,15 +1,17 @@
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useGroupMemberInviteDialog } from './useGroupMemberInviteDialog'
 
-const invalidate = vi.fn()
-const mockUseRouter = vi.fn(() => ({ invalidate }))
-const mockUseServerFn = vi.fn(() => vi.fn())
-const toast = {
-  error: vi.fn(),
-  success: vi.fn(),
-  warning: vi.fn(),
-}
+const { invalidate, mockUseRouter, mockUseServerFn, toast } = vi.hoisted(() => ({
+  invalidate: vi.fn(),
+  mockUseRouter: vi.fn(() => ({ invalidate })),
+  mockUseServerFn: vi.fn(() => vi.fn()),
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
 
 vi.mock('@tanstack/react-router', () => ({
   useRouter: mockUseRouter,
@@ -37,12 +39,12 @@ describe('useGroupMemberInviteDialog', () => {
     toast.warning.mockReset()
   })
 
-  it('ignores emails that already belong to group members and warns with details', () => {
+  it('ignores emails that already belong to group members and warns with details', async () => {
     const { result } = renderHook(() =>
       useGroupMemberInviteDialog({
         existingMemberEmails: ['ada@example.com'],
         groupId: 'group-1',
-        roles: [{ id: 'role-1', title: 'Researcher' }],
+        roles: [{ id: '1', title: 'Researcher' }],
       }),
     )
 
@@ -54,14 +56,16 @@ describe('useGroupMemberInviteDialog', () => {
       ].join('\n'))
     })
 
-    expect(result.current.inviteRows).toEqual([
-      {
-        id: 'invite-1',
-        email: 'grace@example.com',
-        roleId: 'role-1',
-        isAdmin: false,
-      },
-    ])
+    await waitFor(() => {
+      expect(result.current.inviteRows).toEqual([
+        {
+          id: 'invite-1',
+          email: 'grace@example.com',
+          roleId: '1',
+          isAdmin: false,
+        },
+      ])
+    })
     expect(toast.warning).toHaveBeenCalledWith(
       '1 user is already in this group and was ignored.',
       expect.objectContaining({
@@ -74,12 +78,12 @@ describe('useGroupMemberInviteDialog', () => {
     expect(toast.error).not.toHaveBeenCalled()
   })
 
-  it('still appends new invites when a mixed import also contains existing group members', () => {
+  it('still appends new invites when a mixed import also contains existing group members', async () => {
     const { result } = renderHook(() =>
       useGroupMemberInviteDialog({
         existingMemberEmails: ['ada@example.com'],
         groupId: 'group-1',
-        roles: [{ id: 'role-1', title: 'Researcher' }],
+        roles: [{ id: '1', title: 'Researcher' }],
       }),
     )
 
@@ -95,20 +99,22 @@ describe('useGroupMemberInviteDialog', () => {
       ].join('\n'))
     })
 
-    expect(result.current.inviteRows).toEqual([
-      {
-        id: 'invite-1',
-        email: 'grace@example.com',
-        roleId: 'role-1',
-        isAdmin: false,
-      },
-      {
-        id: 'invite-2',
-        email: 'barbara@example.com',
-        roleId: 'role-1',
-        isAdmin: false,
-      },
-    ])
+    await waitFor(() => {
+      expect(result.current.inviteRows).toEqual([
+        {
+          id: 'invite-1',
+          email: 'grace@example.com',
+          roleId: '1',
+          isAdmin: false,
+        },
+        {
+          id: 'invite-2',
+          email: 'barbara@example.com',
+          roleId: '1',
+          isAdmin: false,
+        },
+      ])
+    })
     expect(toast.warning).toHaveBeenLastCalledWith(
       '1 user is already in this group and was ignored.',
       expect.objectContaining({

--- a/src/features/groups/components/settings/members/useGroupMemberInviteDialog.test.tsx
+++ b/src/features/groups/components/settings/members/useGroupMemberInviteDialog.test.tsx
@@ -1,0 +1,76 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useGroupMemberInviteDialog } from './useGroupMemberInviteDialog'
+
+const invalidate = vi.fn()
+const mockUseRouter = vi.fn(() => ({ invalidate }))
+const mockUseServerFn = vi.fn(() => vi.fn())
+const toast = {
+  error: vi.fn(),
+  success: vi.fn(),
+  warning: vi.fn(),
+}
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: mockUseRouter,
+}))
+
+vi.mock('@tanstack/react-start', () => ({
+  useServerFn: mockUseServerFn,
+}))
+
+vi.mock('sonner', () => ({
+  toast,
+}))
+
+vi.mock('@/features/groups/server/groups/addGroupMembers', () => ({
+  addGroupMembers: {},
+}))
+
+describe('useGroupMemberInviteDialog', () => {
+  beforeEach(() => {
+    invalidate.mockReset()
+    mockUseRouter.mockClear()
+    mockUseServerFn.mockClear()
+    toast.error.mockReset()
+    toast.success.mockReset()
+    toast.warning.mockReset()
+  })
+
+  it('ignores emails that already belong to group members and warns with details', () => {
+    const { result } = renderHook(() =>
+      useGroupMemberInviteDialog({
+        existingMemberEmails: ['ada@example.com'],
+        groupId: 'group-1',
+        roles: [{ id: 'role-1', title: 'Researcher' }],
+      }),
+    )
+
+    act(() => {
+      result.current.handleImportSource([
+        'email,role,access',
+        'ada@example.com,Researcher,admin',
+        'grace@example.com,Researcher,member',
+      ].join('\n'))
+    })
+
+    expect(result.current.inviteRows).toEqual([
+      {
+        id: 'invite-1',
+        email: 'grace@example.com',
+        roleId: 'role-1',
+        isAdmin: false,
+      },
+    ])
+    expect(toast.warning).toHaveBeenCalledWith(
+      '1 user is already in this group and was ignored.',
+      expect.objectContaining({
+        description: 'ada@example.com',
+      }),
+    )
+    expect(toast.success).toHaveBeenCalledWith(
+      'Imported 1 member. Skipped 1 member already in the group.',
+    )
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/groups/components/settings/members/useGroupMemberInviteDialog.test.tsx
+++ b/src/features/groups/components/settings/members/useGroupMemberInviteDialog.test.tsx
@@ -73,4 +73,50 @@ describe('useGroupMemberInviteDialog', () => {
     )
     expect(toast.error).not.toHaveBeenCalled()
   })
+
+  it('still appends new invites when a mixed import also contains existing group members', () => {
+    const { result } = renderHook(() =>
+      useGroupMemberInviteDialog({
+        existingMemberEmails: ['ada@example.com'],
+        groupId: 'group-1',
+        roles: [{ id: 'role-1', title: 'Researcher' }],
+      }),
+    )
+
+    act(() => {
+      result.current.handleImportSource('grace@example.com')
+    })
+
+    act(() => {
+      result.current.handleImportSource([
+        'email,role,access',
+        'ada@example.com,Researcher,admin',
+        'barbara@example.com,Researcher,member',
+      ].join('\n'))
+    })
+
+    expect(result.current.inviteRows).toEqual([
+      {
+        id: 'invite-1',
+        email: 'grace@example.com',
+        roleId: 'role-1',
+        isAdmin: false,
+      },
+      {
+        id: 'invite-2',
+        email: 'barbara@example.com',
+        roleId: 'role-1',
+        isAdmin: false,
+      },
+    ])
+    expect(toast.warning).toHaveBeenLastCalledWith(
+      '1 user is already in this group and was ignored.',
+      expect.objectContaining({
+        description: 'ada@example.com',
+      }),
+    )
+    expect(toast.success).toHaveBeenLastCalledWith(
+      'Imported 1 member. Skipped 1 member already in the group.',
+    )
+  })
 })

--- a/src/features/groups/components/settings/members/useGroupMemberInviteDialog.ts
+++ b/src/features/groups/components/settings/members/useGroupMemberInviteDialog.ts
@@ -24,9 +24,11 @@ import {
 const addGroupMembersFormSchema = addGroupMembersSchema.omit({ groupId: true })
 
 export function useGroupMemberInviteDialog({
+  existingMemberEmails = [],
   groupId,
   roles,
 }: {
+  existingMemberEmails?: string[]
   groupId: string
   roles: GroupSettingsRole[]
 }) {
@@ -72,15 +74,31 @@ export function useGroupMemberInviteDialog({
       return
     }
 
-    const { invites, summary } = importGroupMemberInvites({
+    const { ignoredExistingEmails, invites, summary } = importGroupMemberInvites({
       existingInvites: inviteRows.map(({ email, roleId, isAdmin }) => ({ email, roleId, isAdmin })),
+      existingMemberEmails,
       roles,
       source: trimmedSource,
       defaultRoleId: resolvedDefaultRoleId,
       defaultIsAdmin,
     })
 
+    if (summary.existingMemberCount > 0) {
+      toast.warning(
+        summary.existingMemberCount === 1
+          ? '1 user is already in this group and was ignored.'
+          : `${summary.existingMemberCount} users are already in this group and were ignored.`,
+        {
+          description: ignoredExistingEmails.join('\n'),
+        },
+      )
+    }
+
     if (summary.addedCount === 0) {
+      if (summary.existingMemberCount > 0 && summary.duplicateCount === 0 && summary.invalidCount === 0 && summary.unresolvedRoleCount === 0 && summary.truncatedCount === 0) {
+        return
+      }
+
       toast.error(buildImportSummaryMessage(summary))
       return
     }

--- a/src/features/groups/components/settings/members/useGroupMemberInviteDialog.ts
+++ b/src/features/groups/components/settings/members/useGroupMemberInviteDialog.ts
@@ -74,6 +74,9 @@ export function useGroupMemberInviteDialog({
       return
     }
 
+    const existingInviteEmails = new Set(
+      inviteRows.map(row => row.email.trim().toLowerCase()),
+    )
     const { ignoredExistingEmails, invites, summary } = importGroupMemberInvites({
       existingInvites: inviteRows.map(({ email, roleId, isAdmin }) => ({ email, roleId, isAdmin })),
       existingMemberEmails,
@@ -103,9 +106,13 @@ export function useGroupMemberInviteDialog({
       return
     }
 
+    const newlyImportedInvites = invites.filter(
+      invite => !existingInviteEmails.has(invite.email.trim().toLowerCase()),
+    )
+
     setStoredInviteRows(currentRows => [
       ...currentRows,
-      ...invites.slice(inviteRows.length).map(createInviteRow),
+      ...newlyImportedInvites.map(createInviteRow),
     ])
     setDraftSource('')
     toast.success(buildImportSummaryMessage(summary))

--- a/src/features/groups/lib/groupMemberInviteBatch.test.ts
+++ b/src/features/groups/lib/groupMemberInviteBatch.test.ts
@@ -12,10 +12,12 @@ describe('importGroupMemberInvites', () => {
   it('resolves role and access columns while skipping duplicates and invalid emails', () => {
     const result = importGroupMemberInvites({
       existingInvites: [{ email: 'existing@example.com', roleId: '1', isAdmin: false }],
+      existingMemberEmails: ['already-member@example.com'],
       roles,
       source: [
         'email,role,access',
         'existing@example.com,Owner,member',
+        'already-member@example.com,Owner,admin',
         'alpha@example.com,Reviewer,admin',
         'beta@example.com,Unknown role,member',
         'not-an-email,Researcher,admin',
@@ -29,9 +31,11 @@ describe('importGroupMemberInvites', () => {
       { email: 'alpha@example.com', roleId: '3', isAdmin: true },
       { email: 'beta@example.com', roleId: '2', isAdmin: false },
     ])
+    expect(result.ignoredExistingEmails).toEqual(['already-member@example.com'])
     expect(result.summary).toEqual({
       addedCount: 2,
       duplicateCount: 1,
+      existingMemberCount: 1,
       invalidCount: 1,
       unresolvedRoleCount: 1,
       truncatedCount: 0,
@@ -48,6 +52,7 @@ describe('importGroupMemberInvites', () => {
     })
 
     expect(result.invites).toHaveLength(MAX_GROUP_MEMBER_INVITES)
+    expect(result.ignoredExistingEmails).toEqual([])
     expect(result.summary.truncatedCount).toBe(2)
   })
 })

--- a/src/features/groups/lib/groupMemberInviteBatch.ts
+++ b/src/features/groups/lib/groupMemberInviteBatch.ts
@@ -13,6 +13,7 @@ export interface GroupMemberInviteDraft {
 export interface GroupMemberInviteImportSummary {
   addedCount: number
   duplicateCount: number
+  existingMemberCount: number
   invalidCount: number
   unresolvedRoleCount: number
   truncatedCount: number
@@ -20,6 +21,7 @@ export interface GroupMemberInviteImportSummary {
 
 interface ImportGroupMemberInvitesOptions {
   existingInvites: GroupMemberInviteDraft[]
+  existingMemberEmails?: string[]
   roles: GroupSettingsRole[]
   source: string
   defaultRoleId: string
@@ -39,6 +41,7 @@ export function createEmptyGroupMemberInviteDraft(defaultRoleId: string): GroupM
 
 export function importGroupMemberInvites({
   existingInvites,
+  existingMemberEmails = [],
   roles,
   source,
   defaultRoleId,
@@ -46,15 +49,18 @@ export function importGroupMemberInvites({
 }: ImportGroupMemberInvitesOptions) {
   const rows = parseGroupMemberInviteRows(source)
   const existingEmails = new Set(existingInvites.map(invite => normalizeInviteEmail(invite.email)))
+  const existingGroupMemberEmails = new Set(existingMemberEmails.map(normalizeInviteEmail))
   const roleLookup = buildRoleLookup(roles)
   const summary: GroupMemberInviteImportSummary = {
     addedCount: 0,
     duplicateCount: 0,
+    existingMemberCount: 0,
     invalidCount: 0,
     unresolvedRoleCount: 0,
     truncatedCount: 0,
   }
   const nextInvites = [...existingInvites]
+  const ignoredExistingEmails: string[] = []
 
   for (const row of rows) {
     if (nextInvites.length >= MAX_GROUP_MEMBER_INVITES) {
@@ -79,6 +85,12 @@ export function importGroupMemberInvites({
       continue
     }
 
+    if (existingGroupMemberEmails.has(normalizedEmail)) {
+      summary.existingMemberCount += 1
+      ignoredExistingEmails.push(normalizedEmail)
+      continue
+    }
+
     const resolvedRole = resolveRoleId({
       defaultRoleId,
       roleLookup,
@@ -100,6 +112,7 @@ export function importGroupMemberInvites({
 
   return {
     invites: nextInvites,
+    ignoredExistingEmails,
     summary,
   }
 }

--- a/src/features/groups/lib/pairing.test.ts
+++ b/src/features/groups/lib/pairing.test.ts
@@ -49,6 +49,21 @@ describe('findMissingHelpCapacities', () => {
 })
 
 describe('buildPairs', () => {
+  it('treats missing help-capacity ratings as zero when pairing tasks', () => {
+    const tasks = buildTasks(2)
+
+    expect(buildPairs(tasks, [
+      { taskId: '1', userId: 'user-2', helpCapacity: 4 },
+    ])).toEqual([
+      {
+        firstUser: 'user-1',
+        secondUser: 'user-2',
+        affinity: 4,
+        taskIds: ['1', '2'],
+      },
+    ])
+  })
+
   it('leaves the lowest-scoring task out of the resulting pairs when the pool size is odd', () => {
     const tasks = buildTasks(3)
 

--- a/src/features/groups/lib/pairing/helpCapacities.ts
+++ b/src/features/groups/lib/pairing/helpCapacities.ts
@@ -71,7 +71,8 @@ export function createHelpCapacityLookup(helpCapacities: HelpCapacityCandidate[]
  * @param helpCapacityLookup - Nested lookup built from the persisted ratings.
  * @param taskId - Task being helped.
  * @param helperUserId - User who could help on the task.
- * @returns The directed help score, or `0` when no score exists.
+ * @returns The directed help score, or `0` when no score exists because the
+ * rating was never submitted.
  */
 export function getDirectedAffinity(
   helpCapacityLookup: HelpCapacityLookup,

--- a/src/features/groups/lib/pairing/types.ts
+++ b/src/features/groups/lib/pairing/types.ts
@@ -14,6 +14,7 @@ export interface PairingTaskCandidate {
 
 /**
  * Directed "how much could I help?" score for one user on one task.
+ * Missing ratings are treated as `0` by the pairing pipeline.
  */
 export interface HelpCapacityCandidate {
   /** Task being rated. */

--- a/src/features/groups/server/tasks/makePairs.ts
+++ b/src/features/groups/server/tasks/makePairs.ts
@@ -1,14 +1,13 @@
-import type { MissingHelpCapacity, PairingHistory } from '@/features/groups/lib/pairing'
+import type { PairingHistory } from '@/features/groups/lib/pairing'
 import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
-import { buildPairs, findMissingHelpCapacities } from '@/features/groups/lib/pairing'
+import { buildPairs } from '@/features/groups/lib/pairing'
 import { parseValidatedInput } from '@/features/groups/server/parseValidatedInput'
 
 interface MakePairsResponse {
   success: boolean
   message: string
   data?: {
-    missingHelpCapacities?: MissingHelpCapacity[]
     pairingId?: string
     pairs?: Array<{
       firstUser: string
@@ -20,13 +19,12 @@ interface MakePairsResponse {
 
 const makePairsInputSchema = z.object({
   groupId: z.string(),
-  force: z.boolean().optional().default(false),
 })
 
 export const makePairs = createServerFn({ method: 'POST' })
   .inputValidator((data: unknown) => parseValidatedInput(makePairsInputSchema, data))
   .handler(async ({ data }): Promise<MakePairsResponse> => {
-    const { groupId, force } = data
+    const { groupId } = data
 
     try {
       const { getPrismaClient } = await import('@/shared/server/prisma')
@@ -150,16 +148,6 @@ export const makePairs = createServerFn({ method: 'POST' })
         helpCapacity: capacity.help_capacity,
       }))
       const pairingHistory = buildPairingHistory(pairingTasks, latestPairing?.pair ?? [])
-      const missingHelpCapacities = findMissingHelpCapacities(pairingTasks, pairingHelpCapacities)
-
-      if (!force && missingHelpCapacities.length > 0) {
-        return {
-          success: false,
-          message: `There are ${missingHelpCapacities.length} missing help capacities. Please confirm if you want to proceed.`,
-          data: { missingHelpCapacities },
-        }
-      }
-
       const pairs = buildPairs(pairingTasks, pairingHelpCapacities, pairingHistory)
 
       if (pairs.length === 0) {


### PR DESCRIPTION
## 🐛 Bug Fix

### 📌 Description

This PR fixes several groups interaction issues across pairing and member management. Pair creation now works even when some help-capacity ratings are missing, member management views keep their own scrollable regions, and invite imports now ignore users who are already in the group while still appending valid new invites from mixed imports. It also adds focused test coverage for the updated flows, relaxes a couple of test-only ESLint rules, and updates the repository link in `CITATION.cff`.

### 🔍 Feature Changes

- [x] UI/UX improvement
- [x] Other: expanded test coverage for pairing and group member invite flows

### 🔄 Refactor Changes

- [x] Improve maintainability
- [x] Remove unnecessary code

### 🛠 Bug Fixes

- [x] Allow pair creation when some help-capacity ratings are missing by treating missing ratings as `0`
- [x] Keep hovered pair cards above neighboring cards and make member settings surfaces scroll internally
- [x] Skip existing group members during CSV/text invite imports while still appending valid new invites from mixed imports
- [x] Improve the invitation accept hover state