### PR TITLE
fix(groups): stabilize rating and pairing refreshes & ARIA

### DIFF
--- a/src/features/groups/components/GroupCard.test.tsx
+++ b/src/features/groups/components/GroupCard.test.tsx
@@ -144,4 +144,36 @@ describe('groupCard', () => {
       expect(mockToastError).toHaveBeenCalledWith('Network down')
     })
   })
+
+  it('keeps joined group navigation and settings as separate keyboard targets', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <GroupCard
+        href="group-1"
+        group={{
+          id: 'group-1',
+          groupName: 'Research Collective',
+          groupDescription: 'Weekly paper reviews',
+          role: 'Member',
+          isAdmin: true,
+          isPending: false,
+          joinedAt: '2026-04-10T10:00:00.000Z',
+        }}
+      />,
+    )
+
+    const groupLink = screen.getByRole('link', { name: /Research Collective/i })
+    const settingsButton = screen.getByRole('button', { name: 'Open settings for Research Collective' })
+
+    expect(groupLink).toHaveAttribute('href', '/groups/group-1')
+    expect(settingsButton.closest('a')).toBeNull()
+
+    await user.click(settingsButton)
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/groups/$slug/settings',
+      params: { slug: 'group-1' },
+    })
+  })
 })

--- a/src/features/groups/components/GroupCard.tsx
+++ b/src/features/groups/components/GroupCard.tsx
@@ -50,6 +50,26 @@ const GroupCard = ({
   const isNavigable = href !== undefined
   const acceptPending = controlledIsAccepting ?? isAccepting
 
+  const settingsAction = isAdmin && !isPending
+    ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          type="button"
+          onClick={() => {
+            void router.navigate({
+              to: '/groups/$slug/settings',
+              params: { slug: group.id },
+            })
+          }}
+          aria-label={`Open settings for ${groupName}`}
+          className="absolute right-4 top-4 z-10 hover-lift-sm hover:rotate-2"
+        >
+          <Settings aria-hidden="true" />
+        </Button>
+      )
+    : null
+
   const onAccept = async () => {
     if (onAcceptInvitation !== undefined) {
       try {
@@ -81,29 +101,10 @@ const GroupCard = ({
       )}
     >
       <div className="space-y-2">
-        <CardHeader className="flex justify-between items-center">
+        <CardHeader className={cn('flex justify-between items-center', settingsAction !== null && 'pr-14')}>
           <CardTitle className="transition-colors duration-300 ease-out group-hover:text-foreground/80">
             {groupName}
           </CardTitle>
-          {isAdmin && !isPending && (
-            <Button
-              variant="ghost"
-              size="icon"
-              type="button"
-              onClick={(event_) => {
-                event_.preventDefault()
-                event_.stopPropagation()
-                void router.navigate({
-                  to: '/groups/$slug/settings',
-                  params: { slug: group.id },
-                })
-              }}
-              aria-label="Settings"
-              className="hover-lift-sm hover:rotate-2"
-            >
-              <Settings aria-hidden="true" />
-            </Button>
-          )}
         </CardHeader>
         <CardContent>
           {descriptionParagraphs.length > 0
@@ -163,13 +164,21 @@ const GroupCard = ({
 
   return href !== undefined
     ? (
-        <Link to="/groups/$slug" params={{ slug: href }}>
-          {CardContentComponent}
-        </Link>
+        <div className="relative h-full w-full">
+          <Link
+            to="/groups/$slug"
+            params={{ slug: href }}
+            className="block h-full rounded-xl focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+          >
+            {CardContentComponent}
+          </Link>
+          {settingsAction}
+        </div>
       )
     : (
-        <div className="h-full w-full">
+        <div className="relative h-full w-full">
           {CardContentComponent}
+          {settingsAction}
         </div>
       )
 }

--- a/src/features/groups/components/detail/OthersTasksForm.tsx
+++ b/src/features/groups/components/detail/OthersTasksForm.tsx
@@ -35,7 +35,7 @@ const OthersTasksForm = ({
   const [saveStates, setSaveStates] = useState<Record<string, SaveState>>({})
   const inFlightTaskIdsRef = useRef(new Set<string>())
   const batchInFlightRef = useRef(false)
-  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>()
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const queuedRatingsRef = useRef<TaskRatings>({})
   const savedRatingsRef = useRef<TaskRatings>(buildRatingsMap(tasks))
 
@@ -48,7 +48,14 @@ const OthersTasksForm = ({
   }, [])
 
   useEffect(() => {
-    const nextSavedRatings = buildRatingsMap(tasks)
+    const incomingRatings = buildRatingsMap(tasks)
+    const nextSavedRatings: TaskRatings = {}
+
+    for (const task of tasks) {
+      const incomingRating = incomingRatings[task.id]
+      nextSavedRatings[task.id] = incomingRating ?? savedRatingsRef.current[task.id]
+    }
+
     savedRatingsRef.current = nextSavedRatings
     // eslint-disable-next-line react/set-state-in-effect
     setSavedRatings(nextSavedRatings)

--- a/src/features/groups/components/detail/SingleGroupPageContent.test.tsx
+++ b/src/features/groups/components/detail/SingleGroupPageContent.test.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import SingleGroupPageContent from './SingleGroupPageContent'
 
@@ -60,8 +61,12 @@ function MockLeavePoolButton() {
   return <button type="button">Leave Pool</button>
 }
 
-function MockMakePairsButton() {
-  return <button type="button">Make Pairs</button>
+function MockMakePairsButton({
+  onPairingCreated,
+}: {
+  onPairingCreated?: (pairingId?: string) => void
+}) {
+  return <button type="button" onClick={() => onPairingCreated?.('pairing-1')}>Make Pairs</button>
 }
 
 function MockResetPoolButton() {
@@ -105,7 +110,7 @@ vi.mock('@/features/groups/components/detail/OthersTasks', () => ({
 }))
 
 vi.mock('@/features/groups/components/detail/PairingSuccessConfetti', () => ({
-  default: () => null,
+  default: () => <div data-testid="pairing-confetti" />,
 }))
 
 vi.mock('@/features/groups/components/detail/buttons', () => ({
@@ -407,6 +412,23 @@ describe('singleGroupPageContent', () => {
         ],
       }),
     )
+  })
+
+  it('shows pairing feedback immediately after the admin makes pairs', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <SingleGroupPageContent
+        {...baseProps}
+        initialTasks={[baseTask, teammateTask]}
+      />,
+    )
+
+    expect(screen.queryByTestId('pairing-confetti')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Make Pairs' }))
+
+    expect(screen.getByTestId('pairing-confetti')).toBeInTheDocument()
   })
 
   it('passes active round pair summaries to the admin round panel', () => {

--- a/src/features/groups/components/detail/SingleGroupPageContent.tsx
+++ b/src/features/groups/components/detail/SingleGroupPageContent.tsx
@@ -84,6 +84,14 @@ export default function SingleGroupPageContent({
     previousActivePairingIdRef.current = nextActivePairingId
   }, [groupInfo.activePairingId])
 
+  const handlePairingCreated = (pairingId?: string) => {
+    setShowPairingConfetti(true)
+
+    if (pairingId !== undefined) {
+      previousActivePairingIdRef.current = pairingId
+    }
+  }
+
   return (
     <div className="container mx-auto flex max-w-5xl flex-col gap-6 p-6">
       {showPairingConfetti && (
@@ -117,6 +125,7 @@ export default function SingleGroupPageContent({
                     <MakePairsButton
                       groupId={groupInfo.id}
                       eligibleTaskCount={tasks.length}
+                      onPairingCreated={handlePairingCreated}
                     />
                   )}
                 </>

--- a/src/features/groups/components/detail/buttons/MakePairsButton.tsx
+++ b/src/features/groups/components/detail/buttons/MakePairsButton.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from '@tanstack/react-router'
 import { useServerFn } from '@tanstack/react-start'
-import { useTransition } from 'react'
+import { useState } from 'react'
 import { toast } from 'sonner'
 import { makePairs } from '@/features/groups/server/tasks'
 import { DoubleConfirmDialog } from '@/shared/ui'
@@ -9,10 +9,11 @@ import { Button } from '@/shared/ui/button'
 interface Props {
   groupId: string
   eligibleTaskCount: number
+  onPairingCreated?: (pairingId?: string) => void
 }
 
-const MakePairsButton = ({ groupId, eligibleTaskCount }: Props) => {
-  const [isPending, startTransition] = useTransition()
+const MakePairsButton = ({ groupId, eligibleTaskCount, onPairingCreated }: Props) => {
+  const [isPending, setIsPending] = useState(false)
   const router = useRouter()
   const makePairsFn = useServerFn(makePairs)
   const isDisabled = eligibleTaskCount < 2 || isPending
@@ -23,16 +24,26 @@ const MakePairsButton = ({ groupId, eligibleTaskCount }: Props) => {
       : undefined
 
   const handleMakePairs = async () => {
-    startTransition(async () => {
+    if (isPending) {
+      return
+    }
+
+    setIsPending(true)
+
+    try {
       const response = await makePairsFn({ data: { groupId } })
       if (response.success) {
+        onPairingCreated?.(response.data?.pairingId)
         toast.success(response.message)
         await router.invalidate()
       }
       else {
         toast.error(response.message)
       }
-    })
+    }
+    finally {
+      setIsPending(false)
+    }
   }
 
   return (
@@ -52,6 +63,7 @@ const MakePairsButton = ({ groupId, eligibleTaskCount }: Props) => {
       confirmText="Make Pairs"
       cancelText="Cancel"
       onConfirm={handleMakePairs}
+      pendingText="Making pairs..."
     />
   )
 }

--- a/src/features/groups/components/detail/buttons/MakePairsButton.tsx
+++ b/src/features/groups/components/detail/buttons/MakePairsButton.tsx
@@ -41,6 +41,10 @@ const MakePairsButton = ({ groupId, eligibleTaskCount, onPairingCreated }: Props
         toast.error(response.message)
       }
     }
+    catch (error) {
+      console.error(error)
+      toast.error('Failed to make pairs. Please try again.')
+    }
     finally {
       setIsPending(false)
     }

--- a/src/features/groups/components/detail/groupsDetail.test.tsx
+++ b/src/features/groups/components/detail/groupsDetail.test.tsx
@@ -147,6 +147,23 @@ describe('groups detail controls', () => {
     expect(mockedToast.success).toHaveBeenCalledWith('Pairs created successfully')
   })
 
+  it('shows an error toast when pair creation throws', async () => {
+    const user = userEvent.setup()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    serverFnMock.mockRejectedValue(new Error('Network down'))
+
+    render(<MakePairsButton groupId="group-1" eligibleTaskCount={3} />)
+
+    await user.click(screen.getByRole('button', { name: 'Confirm Dialog' }))
+
+    await waitFor(() => {
+      expect(mockedToast.error).toHaveBeenCalledWith('Failed to make pairs. Please try again.')
+    })
+    expect(invalidate).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
   it('keeps reset pool available for admins via confirmation dialog', () => {
     render(<ResetPoolButton groupId="group-1" />)
 

--- a/src/features/groups/components/detail/groupsDetail.test.tsx
+++ b/src/features/groups/components/detail/groupsDetail.test.tsx
@@ -21,7 +21,18 @@ const {
   const mockedUseRouter = vi.fn(() => ({
     invalidate,
   }))
-  const mockedDoubleConfirmDialog = ({ trigger }: { trigger: ReactNode }) => <>{trigger}</>
+  const mockedDoubleConfirmDialog = ({
+    trigger,
+    onConfirm,
+  }: {
+    trigger: ReactNode
+    onConfirm: () => Promise<void>
+  }) => (
+    <>
+      {trigger}
+      <button type="button" onClick={() => { void onConfirm() }}>Confirm Dialog</button>
+    </>
+  )
 
   return {
     serverFnMock,
@@ -98,6 +109,42 @@ describe('groups detail controls', () => {
 
     expect(screen.getByRole('button', { name: 'Make Pairs' })).toBeEnabled()
     expect(screen.getByRole('button', { name: 'Make Pairs' })).not.toHaveAttribute('title')
+  })
+
+  it('reports pairing creation before refreshing the route', async () => {
+    const user = userEvent.setup()
+    const events: string[] = []
+    const onPairingCreated = vi.fn(() => {
+      events.push('created')
+    })
+
+    serverFnMock.mockResolvedValue({
+      success: true,
+      message: 'Pairs created successfully',
+      data: {
+        pairingId: 'pairing-1',
+      },
+    })
+    invalidate.mockImplementation(async () => {
+      events.push('invalidate')
+    })
+
+    render(
+      <MakePairsButton
+        groupId="group-1"
+        eligibleTaskCount={3}
+        onPairingCreated={onPairingCreated}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Confirm Dialog' }))
+
+    await waitFor(() => {
+      expect(invalidate).toHaveBeenCalledTimes(1)
+    })
+    expect(onPairingCreated).toHaveBeenCalledWith('pairing-1')
+    expect(events).toEqual(['created', 'invalidate'])
+    expect(mockedToast.success).toHaveBeenCalledWith('Pairs created successfully')
   })
 
   it('keeps reset pool available for admins via confirmation dialog', () => {
@@ -269,6 +316,73 @@ describe('groups detail controls', () => {
           { taskId: 'task-2', capacity: 4 },
         ],
       },
+    })
+  })
+
+  it('keeps saved ratings selected when realtime pool tasks refresh without rating payload', async () => {
+    const user = userEvent.setup()
+    const selfTask: Task = {
+      id: 'task-self',
+      description: 'My draft',
+      userId: 'user-1',
+      fullName: 'Me',
+      avatarUrl: null,
+      helpCapacity: null,
+      ratingsCompletedCount: 0,
+    }
+    const teammateTask: Task = {
+      id: 'task-1',
+      description: 'Review draft intro',
+      userId: 'user-2',
+      fullName: 'Teammate One',
+      avatarUrl: null,
+      helpCapacity: null,
+      ratingsCompletedCount: 0,
+    }
+    const newTeammateTask: Task = {
+      id: 'task-2',
+      description: 'Check appendix',
+      userId: 'user-3',
+      fullName: 'Teammate Two',
+      avatarUrl: null,
+      helpCapacity: null,
+      ratingsCompletedCount: 0,
+    }
+
+    serverFnMock.mockResolvedValue({ success: true, message: 'saved' })
+
+    const { rerender } = render(
+      <OthersTasksForm
+        currentUserId="user-1"
+        groupId="group-1"
+        raceTasks={[selfTask, teammateTask]}
+        canRate
+        tasks={[teammateTask]}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Rate 3' }))
+
+    await waitFor(() => {
+      expect(serverFnMock).toHaveBeenCalledTimes(1)
+    })
+
+    rerender(
+      <OthersTasksForm
+        currentUserId="user-1"
+        groupId="group-1"
+        raceTasks={[selfTask, teammateTask, newTeammateTask]}
+        canRate
+        tasks={[teammateTask, newTeammateTask]}
+      />,
+    )
+
+    await waitFor(() => {
+      const taskRatingButton = screen
+        .getAllByRole('button', { name: 'Rate 3' })
+        .find(button => button.getAttribute('data-task-id') === 'task-1')
+
+      expect(taskRatingButton).toHaveAttribute('aria-pressed', 'true')
     })
   })
 

--- a/src/features/groups/components/settings/GroupSettingsPage.tsx
+++ b/src/features/groups/components/settings/GroupSettingsPage.tsx
@@ -76,7 +76,7 @@ export default function GroupSettingsPage({ settings }: GroupSettingsPageProps) 
         </Button>
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-3">
-            <FolderCogIcon className="size-5 text-muted-foreground" />
+            <FolderCogIcon className="size-5 text-muted-foreground" aria-hidden="true" />
             <h1 className="text-3xl font-semibold tracking-tight">Group settings</h1>
           </div>
           <p className="max-w-3xl text-muted-foreground">
@@ -90,7 +90,7 @@ export default function GroupSettingsPage({ settings }: GroupSettingsPageProps) 
 
       <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
         <span className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1">
-          <UsersIcon className="size-4" />
+          <UsersIcon className="size-4" aria-hidden="true" />
           <span>
             {confirmedMembers.length}
             {' '}
@@ -98,7 +98,7 @@ export default function GroupSettingsPage({ settings }: GroupSettingsPageProps) 
           </span>
         </span>
         <span className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1">
-          <ShieldCheckIcon className="size-4" />
+          <ShieldCheckIcon className="size-4" aria-hidden="true" />
           <span>
             {adminMembers.length}
             {' '}
@@ -106,7 +106,7 @@ export default function GroupSettingsPage({ settings }: GroupSettingsPageProps) 
           </span>
         </span>
         <span className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1">
-          <KeyRoundIcon className="size-4" />
+          <KeyRoundIcon className="size-4" aria-hidden="true" />
           <span>
             {optimisticSettings.roles.length}
             {' '}
@@ -131,7 +131,10 @@ export default function GroupSettingsPage({ settings }: GroupSettingsPageProps) 
               <CardTitle className="-mb-4">Settings</CardTitle>
             </CardHeader>
             <CardContent>
-              <TabsList className="flex h-auto w-full flex-col items-stretch gap-1 bg-transparent p-0">
+              <TabsList
+                aria-label="Group settings sections"
+                className="flex h-auto w-full flex-col items-stretch gap-1 bg-transparent p-0"
+              >
                 {sections.map((section) => {
                   const SectionIcon = section.icon
 
@@ -141,7 +144,7 @@ export default function GroupSettingsPage({ settings }: GroupSettingsPageProps) 
                       value={section.value}
                       className="h-auto w-full justify-start gap-3 rounded-lg border px-4 py-3 text-left hover:bg-muted data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-sm"
                     >
-                      <SectionIcon />
+                      <SectionIcon aria-hidden="true" />
                       <span className="flex flex-col items-start">
                         <span>{section.title}</span>
                       </span>

--- a/src/features/groups/components/settings/members/GroupMembersToolbar.tsx
+++ b/src/features/groups/components/settings/members/GroupMembersToolbar.tsx
@@ -91,17 +91,17 @@ export default function GroupMembersToolbar({
                 pendingText="Removing selected..."
                 onConfirm={onBulkRemove}
                 trigger={(
-                  <Button
-                    variant="ghost"
-                    className="w-full justify-start px-2"
+                  <DropdownMenuItem
                     disabled={selectedRemovableMembers.length === 0 || isBulkRemoving}
+                    onSelect={event => event.preventDefault()}
                     title={selectedRemovableMembers.length === 0
                       ? 'Select at least one removable member.'
                       : undefined}
+                    className="text-destructive focus:text-destructive"
                   >
                     <Trash2Icon data-icon="inline-start" />
                     Remove selected
-                  </Button>
+                  </DropdownMenuItem>
                 )}
               />
             </DropdownMenuGroup>

--- a/src/features/groups/components/settings/roles/RoleTitleInlineEditor.tsx
+++ b/src/features/groups/components/settings/roles/RoleTitleInlineEditor.tsx
@@ -78,6 +78,7 @@ export default function RoleTitleInlineEditor({
         type="button"
         className="inline-flex items-center gap-2 text-left font-medium hover:text-foreground"
         disabled={role.isOptimistic === true}
+        aria-label={`Edit role ${role.title}`}
         onClick={() => {
           setDraftTitle(role.title)
           setIsEditing(true)
@@ -93,6 +94,7 @@ export default function RoleTitleInlineEditor({
     <div className="flex min-w-55 items-center gap-2">
       <Input
         value={draftTitle}
+        aria-label={`Role title for ${role.title}`}
         aria-invalid={!validation.success}
         onChange={event => setDraftTitle(event.target.value)}
         onKeyDown={(event) => {

--- a/src/features/groups/server/tasks/makePairs.ts
+++ b/src/features/groups/server/tasks/makePairs.ts
@@ -20,6 +20,7 @@ interface MakePairsResponse {
 const makePairsInputSchema = z.object({
   groupId: z.string(),
 })
+const ACTIVE_PAIRING_EXISTS_MESSAGE = 'This group already has an active pairing. Reset the pool before making new pairs.'
 
 export const makePairs = createServerFn({ method: 'POST' })
   .inputValidator((data: unknown) => parseValidatedInput(makePairsInputSchema, data))
@@ -77,7 +78,7 @@ export const makePairs = createServerFn({ method: 'POST' })
       if (group.pairing_group_active_pairing_idTopairing !== null) {
         return {
           success: false,
-          message: 'This group already has an active pairing. Reset the pool before making new pairs.',
+          message: ACTIVE_PAIRING_EXISTS_MESSAGE,
         }
       }
 
@@ -157,56 +158,64 @@ export const makePairs = createServerFn({ method: 'POST' })
         }
       }
 
-      const pairing = await prisma.pairing.create({
-        data: {
-          group_id: groupId,
-        },
-      })
-
-      for (const pair of pairs) {
-        await prisma.pair.create({
-          data: {
-            pairing_id: pairing.id,
-            first_user: pair.firstUser,
-            second_user: pair.secondUser,
-          },
-        })
-
-        await prisma.affinity.create({
-          data: {
-            pairing_id: pairing.id,
-            helpee_id: pair.firstUser,
-            helper_id: pair.secondUser,
-            value: pair.affinity,
-          },
-        })
-
-        await prisma.affinity.create({
-          data: {
-            pairing_id: pairing.id,
-            helpee_id: pair.secondUser,
-            helper_id: pair.firstUser,
-            value: pair.affinity,
-          },
-        })
-      }
-
       const pairedTaskIds = pairs.flatMap(pair => pair.taskIds).map(taskId => BigInt(taskId))
 
-      await prisma.task.updateMany({
-        where: {
-          id: {
-            in: pairedTaskIds,
+      const pairing = await prisma.$transaction(async (tx) => {
+        const nextPairing = await tx.pairing.create({
+          data: {
+            group_id: groupId,
           },
-        },
-        data: {
-          pairing_id: pairing.id,
-        },
-      })
+        })
 
-      await prisma.group.update({
-        where: { id: groupId },
-        data: { active_pairing_id: pairing.id },
+        await tx.pair.createMany({
+          data: pairs.map(pair => ({
+            pairing_id: nextPairing.id,
+            first_user: pair.firstUser,
+            second_user: pair.secondUser,
+          })),
+        })
+
+        await tx.affinity.createMany({
+          data: pairs.flatMap(pair => [
+            {
+              pairing_id: nextPairing.id,
+              helpee_id: pair.firstUser,
+              helper_id: pair.secondUser,
+              value: pair.affinity,
+            },
+            {
+              pairing_id: nextPairing.id,
+              helpee_id: pair.secondUser,
+              helper_id: pair.firstUser,
+              value: pair.affinity,
+            },
+          ]),
+        })
+
+        await tx.task.updateMany({
+          where: {
+            id: {
+              in: pairedTaskIds,
+            },
+          },
+          data: {
+            pairing_id: nextPairing.id,
+          },
+        })
+
+        const activatedGroup = await tx.group.updateMany({
+          where: {
+            id: groupId,
+            active_pairing_id: null,
+          },
+          data: { active_pairing_id: nextPairing.id },
+        })
+
+        if (activatedGroup.count === 0) {
+          throw new Error(ACTIVE_PAIRING_EXISTS_MESSAGE)
+        }
+
+        return nextPairing
       })
 
       return {
@@ -223,6 +232,10 @@ export const makePairs = createServerFn({ method: 'POST' })
       }
     }
     catch (error) {
+      if (error instanceof Error && error.message === ACTIVE_PAIRING_EXISTS_MESSAGE) {
+        return { success: false, message: ACTIVE_PAIRING_EXISTS_MESSAGE }
+      }
+
       console.error(error)
       return { success: false, message: 'Failed to make pairs' }
     }

--- a/src/features/groups/server/tasks/makePairs.ts
+++ b/src/features/groups/server/tasks/makePairs.ts
@@ -21,6 +21,7 @@ const makePairsInputSchema = z.object({
   groupId: z.string(),
 })
 const ACTIVE_PAIRING_EXISTS_MESSAGE = 'This group already has an active pairing. Reset the pool before making new pairs.'
+const POOL_CHANGED_MESSAGE = 'The pool changed before pairs could be created. Please review the current pool and try again.'
 
 export const makePairs = createServerFn({ method: 'POST' })
   .inputValidator((data: unknown) => parseValidatedInput(makePairsInputSchema, data))
@@ -167,6 +168,38 @@ export const makePairs = createServerFn({ method: 'POST' })
           },
         })
 
+        const activatedGroup = await tx.group.updateMany({
+          where: {
+            id: groupId,
+            active_pairing_id: null,
+          },
+          data: { active_pairing_id: nextPairing.id },
+        })
+
+        if (activatedGroup.count === 0) {
+          throw new Error(ACTIVE_PAIRING_EXISTS_MESSAGE)
+        }
+
+        const pairedTasks = await tx.task.updateMany({
+          where: {
+            group_id: groupId,
+            id: {
+              in: pairedTaskIds,
+            },
+            pairing_id: null,
+            delete_pending: {
+              not: true,
+            },
+          },
+          data: {
+            pairing_id: nextPairing.id,
+          },
+        })
+
+        if (pairedTasks.count !== pairedTaskIds.length) {
+          throw new Error(POOL_CHANGED_MESSAGE)
+        }
+
         await tx.pair.createMany({
           data: pairs.map(pair => ({
             pairing_id: nextPairing.id,
@@ -192,29 +225,6 @@ export const makePairs = createServerFn({ method: 'POST' })
           ]),
         })
 
-        await tx.task.updateMany({
-          where: {
-            id: {
-              in: pairedTaskIds,
-            },
-          },
-          data: {
-            pairing_id: nextPairing.id,
-          },
-        })
-
-        const activatedGroup = await tx.group.updateMany({
-          where: {
-            id: groupId,
-            active_pairing_id: null,
-          },
-          data: { active_pairing_id: nextPairing.id },
-        })
-
-        if (activatedGroup.count === 0) {
-          throw new Error(ACTIVE_PAIRING_EXISTS_MESSAGE)
-        }
-
         return nextPairing
       })
 
@@ -234,6 +244,10 @@ export const makePairs = createServerFn({ method: 'POST' })
     catch (error) {
       if (error instanceof Error && error.message === ACTIVE_PAIRING_EXISTS_MESSAGE) {
         return { success: false, message: ACTIVE_PAIRING_EXISTS_MESSAGE }
+      }
+
+      if (error instanceof Error && error.message === POOL_CHANGED_MESSAGE) {
+        return { success: false, message: POOL_CHANGED_MESSAGE }
       }
 
       console.error(error)

--- a/src/shared/ui/data-table/DataTable.tsx
+++ b/src/shared/ui/data-table/DataTable.tsx
@@ -83,6 +83,7 @@ export function DataTable<TData, TValue>({
           ? <div />
           : (
               <Input
+                aria-label={filterPlaceholder}
                 value={(table.getColumn(filterColumnId)?.getFilterValue() as string | undefined) ?? ''}
                 onChange={event => table.getColumn(filterColumnId)?.setFilterValue(event.target.value)}
                 placeholder={filterPlaceholder}

--- a/src/shared/ui/data-table/DataTableColumnHeader.tsx
+++ b/src/shared/ui/data-table/DataTableColumnHeader.tsx
@@ -32,7 +32,12 @@ export function DataTableColumnHeader<TData, TValue>({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm" className="-ml-3 h-8">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="-ml-3 h-8"
+          aria-label={`Column options for ${title}`}
+        >
           <span>{title}</span>
           <Icon data-icon="inline-end" />
         </Button>
@@ -41,18 +46,18 @@ export function DataTableColumnHeader<TData, TValue>({
         <DropdownMenuGroup>
           {column.getCanSort() && (
             <>
-              <DropdownMenuItem onClick={() => column.toggleSorting(false)}>
+              <DropdownMenuItem onSelect={() => column.toggleSorting(false)}>
                 <ArrowUpIcon data-icon="inline-start" />
                 Asc
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => column.toggleSorting(true)}>
+              <DropdownMenuItem onSelect={() => column.toggleSorting(true)}>
                 <ArrowDownIcon data-icon="inline-start" />
                 Desc
               </DropdownMenuItem>
             </>
           )}
           {column.getCanHide() && (
-            <DropdownMenuItem onClick={() => column.toggleVisibility(false)}>
+            <DropdownMenuItem onSelect={() => column.toggleVisibility(false)}>
               <EyeOffIcon data-icon="inline-start" />
               Hide column
             </DropdownMenuItem>

--- a/src/shared/ui/data-table/DataTablePagination.tsx
+++ b/src/shared/ui/data-table/DataTablePagination.tsx
@@ -34,7 +34,7 @@ export function DataTablePagination<TData>({
               table.setPageSize(Number(value))
             }}
           >
-            <SelectTrigger className="w-22">
+            <SelectTrigger aria-label="Rows per page" className="w-22">
               <SelectValue placeholder={table.getState().pagination.pageSize} />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
## 🐛 Bug Fix

### 📌 Description

This pull request introduces several improvements and bug fixes to the group management features, focusing on accessibility, user feedback, and state consistency. The most significant changes include refactoring the `GroupCard` for better keyboard navigation and accessibility, ensuring immediate user feedback when pairs are created, and fixing a bug where ratings could be lost on real-time updates. Additional accessibility improvements and test enhancements are also included.

### 🛠 Bug Fixes

- [x] Fixed:
  - Updated the pairing creation flow so that admins see immediate feedback (confetti) when pairs are created, before the page refreshes. This is achieved by introducing an `onPairingCreated` callback in `MakePairsButton` and handling it in `SingleGroupPageContent`.
  - Fixed a bug in `OthersTasksForm` where saved ratings could be lost when real-time updates arrived without a rating payload, ensuring that user selections persist across updates.
- [ ] Improved error handling
- [ ] Performance fix
- [x] Other:
  - Refactored `GroupCard` so that the group navigation link and the settings button are separate, accessible keyboard targets, improving usability for keyboard and screen reader users. The settings button is no longer nested inside the link and has an appropriate `aria-label`.
  - Added `aria-hidden="true"` to decorative icons and improved ARIA labeling for group settings sections and tabs for better screen reader support.
  - Updated the "Remove selected" action in the group members toolbar to use a `DropdownMenuItem` for better accessibility and consistency.

### ✅ Checklist

1. Bug Fixes:

- [x] Bug has been reproduced and verified.
- [x] Fix does not introduce new issues.
- [x] Added necessary tests.
