### PR TITLE
feat: add SEO metadata and Google One Tap sign-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ DATABASE_URL="postgresql://postgres.<your-project-id>:<your-project-password>@<y
 SUPABASE_SECRET_KEY=sb_secret_<your-secret-key>
 
 VITE_SITE_BASE_URL="https://pairresearch.io"
+VITE_GOOGLE_CLIENT_ID="<your-google-oauth-client-id>.apps.googleusercontent.com"
 R2_PUBLIC_DOMAIN="https://r2.pairresearch.io"
 
 VITE_CLOUDFLARE_TURNSTILE_SITE_KEY="<your-turnstile-site-key>"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import antfu from '@antfu/eslint-config'
 export default antfu({
   formatters: true,
   react: true,
-  ignores: ['src/components/ui/**.tsx', 'src/routeTree.gen.ts', '.output/**', 'prisma/generated/**'],
+  ignores: ['src/components/ui/**.tsx', 'src/routeTree.gen.ts', '.output/**', 'prisma/generated/**', 'e2e/.auth/**'],
   typescript: {
     tsconfigPath: 'tsconfig.json',
   },

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "jsdom": "^29.1.1",
     "nano-staged": "^1.0.2",
     "prisma": "^7.8.0",
+    "schema-dts": "^2.0.0",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       prisma:
         specifier: ^7.8.0
         version: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      schema-dts:
+        specifier: ^2.0.0
+        version: 2.0.0(typescript@6.0.3)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -4393,6 +4396,15 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  schema-dts-lib@1.0.0:
+    resolution: {integrity: sha512-9MEO5vpQH9JdBioUupqluzxSYxPLjhmqRUudk15adUl/ypnRsM2/M1kN3AmVJQeG7nZqcL68H8JlGqQQT6vy9A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+
+  schema-dts@2.0.0:
+    resolution: {integrity: sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw==}
 
   scslre@0.3.0:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
@@ -9221,6 +9233,16 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
+
+  schema-dts-lib@1.0.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  schema-dts@2.0.0(typescript@6.0.3):
+    dependencies:
+      schema-dts-lib: 1.0.0(typescript@6.0.3)
+    transitivePeerDependencies:
+      - typescript
 
   scslre@0.3.0:
     dependencies:

--- a/src/features/auth/components/GoogleOneTap.tsx
+++ b/src/features/auth/components/GoogleOneTap.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+import { getGooglePublicEnv } from '@/shared/config/env'
+import { createClient } from '@/shared/supabase/client'
+import { buildPostGoogleAuthRedirectUrl, signInWithGoogleIdToken } from '../lib/googleAuth'
+import { getGoogleOneTapNextPath, shouldShowGoogleOneTap } from '../lib/googleOneTap'
+
+const GOOGLE_IDENTITY_SCRIPT_ID = 'google-identity-services'
+const GOOGLE_IDENTITY_SCRIPT_SRC = 'https://accounts.google.com/gsi/client'
+
+let googleIdentityScriptPromise: Promise<void> | null = null
+
+async function loadGoogleIdentityScript() {
+  if (window.google?.accounts?.id !== undefined) {
+    return Promise.resolve()
+  }
+
+  if (googleIdentityScriptPromise !== null) {
+    return googleIdentityScriptPromise
+  }
+
+  googleIdentityScriptPromise = new Promise((resolve, reject) => {
+    const existingScript = document.getElementById(GOOGLE_IDENTITY_SCRIPT_ID) as HTMLScriptElement | null
+    if (existingScript !== null) {
+      existingScript.addEventListener('load', () => resolve(), { once: true })
+      existingScript.addEventListener('error', () => reject(new Error('Failed to load Google One Tap.')), { once: true })
+      return
+    }
+
+    const script = document.createElement('script')
+    script.id = GOOGLE_IDENTITY_SCRIPT_ID
+    script.src = GOOGLE_IDENTITY_SCRIPT_SRC
+    script.async = true
+    script.defer = true
+    script.addEventListener('load', () => resolve(), { once: true })
+    script.addEventListener('error', () => reject(new Error('Failed to load Google One Tap.')), { once: true })
+    document.head.append(script)
+  })
+
+  return googleIdentityScriptPromise
+}
+
+export default function GoogleOneTap() {
+  const isSigningInRef = useRef(false)
+
+  useEffect(() => {
+    const { clientId } = getGooglePublicEnv()
+    if (clientId === '' || navigator.webdriver || !shouldShowGoogleOneTap(globalThis.location.pathname)) {
+      return
+    }
+
+    let mounted = true
+    const supabase = createClient()
+    const nextPath = getGoogleOneTapNextPath(globalThis.location)
+
+    async function promptForGoogleAccount() {
+      try {
+        const { data } = await supabase.auth.getSession()
+        if (!mounted || data.session !== null) {
+          return
+        }
+
+        await loadGoogleIdentityScript()
+        if (!mounted || window.google?.accounts?.id === undefined) {
+          return
+        }
+
+        window.google.accounts.id.initialize({
+          client_id: clientId,
+          context: 'signin',
+          cancel_on_tap_outside: true,
+          itp_support: true,
+          callback: async (response) => {
+            if (isSigningInRef.current || response.credential === undefined || response.credential === '') {
+              return
+            }
+
+            isSigningInRef.current = true
+            const { error } = await signInWithGoogleIdToken(supabase, response.credential)
+            if (error !== null) {
+              isSigningInRef.current = false
+              toast.error(error.message)
+              return
+            }
+
+            window.google?.accounts.id.cancel()
+            globalThis.location.assign(buildPostGoogleAuthRedirectUrl(nextPath, globalThis.location.origin))
+          },
+        })
+
+        window.google.accounts.id.prompt()
+      }
+      catch (error) {
+        console.warn(error)
+      }
+    }
+
+    void promptForGoogleAccount()
+
+    return () => {
+      mounted = false
+      window.google?.accounts.id.cancel()
+    }
+  }, [])
+
+  return null
+}

--- a/src/features/auth/components/OAuthButton.tsx
+++ b/src/features/auth/components/OAuthButton.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 import { createClient } from '@/shared/supabase/client'
 import { Spinner } from '@/shared/ui'
 import { Button } from '@/shared/ui/button'
+import { startGoogleOAuth } from '../lib/googleAuth'
 
 interface OAuthButtonProps {
   label?: string
@@ -19,15 +20,7 @@ export const OAuthButton = ({
   const handleGoogle = async () => {
     setLoading(true)
     try {
-      const redirectTo = new URL('/auth/callback', globalThis.location.origin)
-      redirectTo.searchParams.set('next', nextPath)
-
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: 'google',
-        options: {
-          redirectTo: redirectTo.toString(),
-        },
-      })
+      const { error } = await startGoogleOAuth(supabase, nextPath, globalThis.location.origin)
 
       if (error) {
         setLoading(false)
@@ -50,7 +43,7 @@ export const OAuthButton = ({
       >
         {loading
           ? (
-              <Spinner text="Redirecting to Google.." className="w-5" />
+              <Spinner text="Redirecting to Google..." className="w-5" />
             )
           : (
               <>

--- a/src/features/auth/lib/googleAuth.test.ts
+++ b/src/features/auth/lib/googleAuth.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildGoogleAuthCallbackUrl,
+  buildPostGoogleAuthRedirectUrl,
+  startGoogleOAuth,
+} from './googleAuth'
+
+describe('googleAuth', () => {
+  it('builds sanitized OAuth callback URLs', () => {
+    expect(buildGoogleAuthCallbackUrl('/groups?view=mine', 'https://pairresearch.io')).toBe(
+      'https://pairresearch.io/auth/callback?next=%2Fgroups%3Fview%3Dmine',
+    )
+
+    expect(buildGoogleAuthCallbackUrl('https://evil.example/groups', 'https://pairresearch.io')).toBe(
+      'https://pairresearch.io/auth/callback?next=%2Fgroups',
+    )
+  })
+
+  it('builds sanitized post-auth redirect URLs with the auth source marker', () => {
+    expect(buildPostGoogleAuthRedirectUrl('/groups/demo', 'https://pairresearch.io')).toBe(
+      'https://pairresearch.io/groups/demo?from=auth-login',
+    )
+  })
+
+  it('starts Google OAuth with the same callback route used by existing auth flow', async () => {
+    const signInWithOAuth = vi.fn(async () => ({ error: null }))
+    const authClient = {
+      auth: {
+        signInWithOAuth,
+        signInWithIdToken: vi.fn(),
+      },
+    }
+
+    await startGoogleOAuth(authClient, '/groups/demo', 'https://pairresearch.io')
+
+    expect(signInWithOAuth).toHaveBeenCalledWith({
+      provider: 'google',
+      options: {
+        redirectTo: 'https://pairresearch.io/auth/callback?next=%2Fgroups%2Fdemo',
+      },
+    })
+  })
+})

--- a/src/features/auth/lib/googleAuth.ts
+++ b/src/features/auth/lib/googleAuth.ts
@@ -1,0 +1,55 @@
+import { sanitizeRedirectPath } from './authRedirect'
+
+interface GoogleOAuthClient {
+  auth: {
+    signInWithOAuth: (args: {
+      provider: 'google'
+      options: {
+        redirectTo: string
+      }
+    }) => Promise<{ error: { message: string } | null }>
+    signInWithIdToken: (args: {
+      provider: 'google'
+      token: string
+    }) => Promise<{ error: { message: string } | null }>
+  }
+}
+
+export const GOOGLE_AUTH_REDIRECT_SOURCE = 'auth-login'
+
+export function buildGoogleAuthCallbackUrl(nextPath: string, origin: string) {
+  const redirectTo = new URL('/auth/callback', origin)
+  redirectTo.searchParams.set('next', sanitizeRedirectPath(nextPath, '/groups'))
+
+  return redirectTo.toString()
+}
+
+export function buildPostGoogleAuthRedirectUrl(nextPath: string, origin: string) {
+  const redirectUrl = new URL(sanitizeRedirectPath(nextPath, '/groups'), origin)
+  redirectUrl.searchParams.set('from', GOOGLE_AUTH_REDIRECT_SOURCE)
+
+  return redirectUrl.toString()
+}
+
+export async function startGoogleOAuth(
+  authClient: GoogleOAuthClient,
+  nextPath: string,
+  origin: string,
+) {
+  return authClient.auth.signInWithOAuth({
+    provider: 'google',
+    options: {
+      redirectTo: buildGoogleAuthCallbackUrl(nextPath, origin),
+    },
+  })
+}
+
+export async function signInWithGoogleIdToken(
+  authClient: GoogleOAuthClient,
+  credential: string,
+) {
+  return authClient.auth.signInWithIdToken({
+    provider: 'google',
+    token: credential,
+  })
+}

--- a/src/features/auth/lib/googleOneTap.test.ts
+++ b/src/features/auth/lib/googleOneTap.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { getGoogleOneTapNextPath, shouldShowGoogleOneTap } from './googleOneTap'
+
+describe('googleOneTap', () => {
+  it('only prompts on public entry and auth pages', () => {
+    expect(shouldShowGoogleOneTap('/')).toBe(true)
+    expect(shouldShowGoogleOneTap('/login')).toBe(true)
+    expect(shouldShowGoogleOneTap('/signup')).toBe(true)
+    expect(shouldShowGoogleOneTap('/groups')).toBe(false)
+    expect(shouldShowGoogleOneTap('/privacy')).toBe(false)
+  })
+
+  it('sanitizes next path values from auth page search params', () => {
+    expect(getGoogleOneTapNextPath({ pathname: '/login', search: '?next=%2Fgroups%2Fdemo' })).toBe('/groups/demo')
+    expect(getGoogleOneTapNextPath({ pathname: '/login', search: '?next=https%3A%2F%2Fevil.example' })).toBe('/groups')
+    expect(getGoogleOneTapNextPath({ pathname: '/', search: '' })).toBe('/groups')
+  })
+})

--- a/src/features/auth/lib/googleOneTap.ts
+++ b/src/features/auth/lib/googleOneTap.ts
@@ -1,0 +1,18 @@
+import { sanitizeRedirectPath } from './authRedirect'
+
+const ONE_TAP_PUBLIC_PATHS = new Set(['/', '/login', '/signup'])
+
+export function shouldShowGoogleOneTap(pathname: string) {
+  return ONE_TAP_PUBLIC_PATHS.has(pathname)
+}
+
+export function getGoogleOneTapNextPath(location: Pick<Location, 'pathname' | 'search'>) {
+  const searchParams = new URLSearchParams(location.search)
+  const nextPath = searchParams.get('next')
+
+  if (nextPath !== null) {
+    return sanitizeRedirectPath(nextPath, '/groups')
+  }
+
+  return '/groups'
+}

--- a/src/features/home/components/HomePage.tsx
+++ b/src/features/home/components/HomePage.tsx
@@ -4,7 +4,8 @@ export default function HomePage() {
   return (
     <div className="flex flex-col items-center space-y-12 px-4 pb-8">
       <section className="animate-subtle-rise max-w-3xl text-center">
-        <p className="text-2xl font-semibold">
+        <h1 className="text-4xl font-semibold tracking-normal sm:text-5xl">Pair Research</h1>
+        <p className="mt-4 text-2xl font-semibold">
           Pair Research is a collaborative method from Delta Lab, designed to help group members overcome blockers and build teams.
         </p>
       </section>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,10 +1,11 @@
 import type { ReactNode } from 'react'
 import { createRootRoute, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
 import { Toaster } from 'sonner'
+import GoogleOneTap from '@/features/auth/components/GoogleOneTap'
 import { Footer, Header } from '@/shared/components/layout'
-import { SITE_BASE_URL } from '@/shared/config/constants'
 import GlobalErrorPage from '@/shared/errors/GlobalErrorPage'
 import NotFoundPage from '@/shared/errors/NotFoundPage'
+import { buildRootSeoMeta } from '@/shared/seo'
 import { TooltipProvider } from '@/shared/ui/tooltip'
 import appleIcon from './apple-icon.png?url'
 import favicon from './favicon.ico?url'
@@ -21,17 +22,8 @@ export const Route = createRootRoute({
       { rel: 'icon', type: 'image/svg+xml', href: icon0 ?? '/icon0.svg' },
     ]
 
-    if (SITE_BASE_URL !== '') {
-      links.push({ rel: 'canonical', href: SITE_BASE_URL })
-    }
-
     return {
-      meta: [
-        { charSet: 'utf-8' },
-        { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-        { title: 'Pair Research' },
-        { name: 'robots', content: 'noindex, nofollow' },
-      ],
+      meta: buildRootSeoMeta(),
       links,
     }
   },
@@ -44,6 +36,7 @@ function RootComponent() {
   return (
     <RootDocument>
       <TooltipProvider>
+        <GoogleOneTap />
         <Toaster position="top-center" richColors />
         <Header />
         <main className="mt-10 grow motion-safe:animate-fade-in-down">

--- a/src/routes/_authed.tsx
+++ b/src/routes/_authed.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router'
 import { getCurrentUser } from '@/features/auth/server'
+import { SEO_NOINDEX_ROBOTS } from '@/shared/seo'
 
 export const Route = createFileRoute('/_authed')({
   beforeLoad: async ({ location }) => {
@@ -11,5 +12,8 @@ export const Route = createFileRoute('/_authed')({
 
     return { user }
   },
+  head: () => ({
+    meta: [{ name: 'robots', content: SEO_NOINDEX_ROBOTS }],
+  }),
   component: Outlet,
 })

--- a/src/routes/forgot-password.tsx
+++ b/src/routes/forgot-password.tsx
@@ -2,11 +2,15 @@ import { createFileRoute } from '@tanstack/react-router'
 import AuthPageShell from '@/features/auth/components/AuthPageShell'
 import ForgotPasswordForm from '@/features/auth/components/ForgotPasswordForm'
 import { authPageSearchSchema, buildAuthPageHref } from '@/features/auth/schemas/authSearch'
+import { buildSeoHead, SEO_NOINDEX_ROBOTS } from '@/shared/seo'
 
 export const Route = createFileRoute('/forgot-password')({
   validateSearch: search => authPageSearchSchema.parse(search),
-  head: () => ({
-    meta: [{ title: 'Forgot password | Pair Research' }],
+  head: () => buildSeoHead({
+    title: 'Reset your password',
+    description: 'Request a secure Pair Research password reset link.',
+    path: '/forgot-password',
+    robots: SEO_NOINDEX_ROBOTS,
   }),
   component: ForgotPasswordPage,
 })

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router'
 import HomePage from '@/features/home/components/HomePage'
+import {
+  buildOrganizationJsonLd,
+  buildSeoHead,
+  buildSoftwareApplicationJsonLd,
+  buildWebSiteJsonLd,
+} from '@/shared/seo'
 
 export const Route = createFileRoute('/')({
+  head: () => buildSeoHead({
+    title: 'Collaborative Peer Support for Research Groups',
+    description: 'Pair Research helps academic teams match collaborators, overcome blockers, and coordinate structured peer support inside research and classroom groups.',
+    path: '/',
+    jsonLd: [
+      buildOrganizationJsonLd(),
+      buildWebSiteJsonLd(),
+      buildSoftwareApplicationJsonLd(),
+    ],
+  }),
   component: HomePage,
 })

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,12 +3,14 @@ import HomePage from '@/features/home/components/HomePage'
 import {
   buildPairResearchJsonLd,
   buildSeoHead,
+  SEO_HOME_KEYWORDS,
 } from '@/shared/seo'
 
 export const Route = createFileRoute('/')({
   head: () => buildSeoHead({
     description: 'Pair Research helps academic teams match collaborators, overcome blockers, and coordinate structured peer support inside research and classroom groups.',
     path: '/',
+    keywords: SEO_HOME_KEYWORDS,
     jsonLd: buildPairResearchJsonLd(),
   }),
   component: HomePage,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,22 +1,15 @@
 import { createFileRoute } from '@tanstack/react-router'
 import HomePage from '@/features/home/components/HomePage'
 import {
-  buildOrganizationJsonLd,
+  buildPairResearchJsonLd,
   buildSeoHead,
-  buildSoftwareApplicationJsonLd,
-  buildWebSiteJsonLd,
 } from '@/shared/seo'
 
 export const Route = createFileRoute('/')({
   head: () => buildSeoHead({
-    title: 'Collaborative Peer Support for Research Groups',
     description: 'Pair Research helps academic teams match collaborators, overcome blockers, and coordinate structured peer support inside research and classroom groups.',
     path: '/',
-    jsonLd: [
-      buildOrganizationJsonLd(),
-      buildWebSiteJsonLd(),
-      buildSoftwareApplicationJsonLd(),
-    ],
+    jsonLd: buildPairResearchJsonLd(),
   }),
   component: HomePage,
 })

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -3,6 +3,7 @@ import AuthPageShell from '@/features/auth/components/AuthPageShell'
 import LoginForm from '@/features/auth/components/LoginForm'
 import { authPageSearchSchema, buildAuthPageHref } from '@/features/auth/schemas/authSearch'
 import { getCurrentUser } from '@/features/auth/server'
+import { buildSeoHead, SEO_NOINDEX_ROBOTS } from '@/shared/seo'
 
 export const Route = createFileRoute('/login')({
   validateSearch: search => authPageSearchSchema.parse(search),
@@ -13,8 +14,11 @@ export const Route = createFileRoute('/login')({
       throw redirect({ href: search.next ?? '/groups' })
     }
   },
-  head: () => ({
-    meta: [{ title: 'Sign in | Pair Research' }],
+  head: () => buildSeoHead({
+    title: 'Sign in',
+    description: 'Sign in to Pair Research with Google or email to manage groups and pair-support workflows.',
+    path: '/login',
+    robots: SEO_NOINDEX_ROBOTS,
   }),
   component: LoginPage,
 })

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import LegalDocumentPage from '@/features/legal/components/LegalDocumentPage'
 import { legalPageSearchSchema } from '@/features/legal/lib/legalLinks'
-import { buildLegalPageJsonLd, buildSeoHead } from '@/shared/seo'
+import { buildLegalPageJsonLd, buildSeoHead, SEO_PRIVACY_KEYWORDS } from '@/shared/seo'
 
 const sections = [
   {
@@ -65,6 +65,7 @@ export const Route = createFileRoute('/privacy')({
     title: 'Privacy Policy',
     description: 'Learn what Pair Research collects, how information is used, and how Northwestern University context affects privacy expectations.',
     path: '/privacy',
+    keywords: SEO_PRIVACY_KEYWORDS,
     jsonLd: buildLegalPageJsonLd({
       title: 'Privacy Policy',
       path: '/privacy',

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import LegalDocumentPage from '@/features/legal/components/LegalDocumentPage'
 import { legalPageSearchSchema } from '@/features/legal/lib/legalLinks'
+import { buildLegalPageJsonLd, buildSeoHead } from '@/shared/seo'
 
 const sections = [
   {
@@ -60,8 +61,15 @@ const references = [
 
 export const Route = createFileRoute('/privacy')({
   validateSearch: search => legalPageSearchSchema.parse(search),
-  head: () => ({
-    meta: [{ title: 'Privacy Policy | Pair Research' }],
+  head: () => buildSeoHead({
+    title: 'Privacy Policy',
+    description: 'Learn what Pair Research collects, how information is used, and how Northwestern University context affects privacy expectations.',
+    path: '/privacy',
+    jsonLd: buildLegalPageJsonLd({
+      title: 'Privacy Policy',
+      path: '/privacy',
+      effectiveDate: '2026-04-14',
+    }),
   }),
   component: PrivacyPage,
 })

--- a/src/routes/reset-password.tsx
+++ b/src/routes/reset-password.tsx
@@ -3,12 +3,16 @@ import { useEffect, useState } from 'react'
 import AuthPageShell from '@/features/auth/components/AuthPageShell'
 import ResetPasswordForm from '@/features/auth/components/ResetPasswordForm'
 import { buildAuthPageHref, resetPasswordSearchSchema } from '@/features/auth/schemas/authSearch'
+import { buildSeoHead, SEO_NOINDEX_ROBOTS } from '@/shared/seo'
 import { createClient } from '@/shared/supabase/client'
 
 export const Route = createFileRoute('/reset-password')({
   validateSearch: search => resetPasswordSearchSchema.parse(search),
-  head: () => ({
-    meta: [{ title: 'Create new password | Pair Research' }],
+  head: () => buildSeoHead({
+    title: 'Create a new password',
+    description: 'Create a new Pair Research password after opening a secure reset link.',
+    path: '/reset-password',
+    robots: SEO_NOINDEX_ROBOTS,
   }),
   component: ResetPasswordPage,
 })

--- a/src/routes/robots[.]txt.ts
+++ b/src/routes/robots[.]txt.ts
@@ -1,18 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { SITE_BASE_URL } from '@/shared/config/constants'
+import { buildRobotsTxt } from '@/shared/seo'
 
 export const Route = createFileRoute('/robots.txt')({
   server: {
     handlers: {
       GET: () => {
-        const body = [
-          'User-agent: *',
-          'Disallow: /',
-          '',
-          `Sitemap: ${SITE_BASE_URL}/sitemap.xml`,
-        ].join('\n')
-
-        return new Response(body, {
+        return new Response(buildRobotsTxt(), {
           headers: {
             'content-type': 'text/plain; charset=utf-8',
           },

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -4,6 +4,7 @@ import AuthPageShell from '@/features/auth/components/AuthPageShell'
 import SignupForm from '@/features/auth/components/SignupForm'
 import { authPageSearchSchema, buildAuthPageHref } from '@/features/auth/schemas/authSearch'
 import { getCurrentUser } from '@/features/auth/server'
+import { buildSeoHead, SEO_NOINDEX_ROBOTS } from '@/shared/seo'
 
 export const Route = createFileRoute('/signup')({
   validateSearch: search => authPageSearchSchema.parse(search),
@@ -14,8 +15,11 @@ export const Route = createFileRoute('/signup')({
       throw redirect({ href: search.next ?? '/groups' })
     }
   },
-  head: () => ({
-    meta: [{ title: 'Sign up | Pair Research' }],
+  head: () => buildSeoHead({
+    title: 'Create an account',
+    description: 'Create a Pair Research account with Google or email to join groups and coordinate peer support.',
+    path: '/signup',
+    robots: SEO_NOINDEX_ROBOTS,
   }),
   component: SignupPage,
 })

--- a/src/routes/sitemap[.]xml.ts
+++ b/src/routes/sitemap[.]xml.ts
@@ -1,25 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { SITE_BASE_URL } from '@/shared/config/constants'
+import { buildSitemapXml } from '@/shared/seo'
 
 export const Route = createFileRoute('/sitemap.xml')({
   server: {
     handlers: {
       GET: () => {
-        if (SITE_BASE_URL === '') {
-          throw new Error('SITE_BASE_URL is not defined')
-        }
-
-        const body = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>${SITE_BASE_URL}</loc>
-    <lastmod>${new Date().toISOString()}</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>1.0</priority>
-  </url>
-</urlset>`
-
-        return new Response(body, {
+        return new Response(buildSitemapXml(), {
           headers: {
             'content-type': 'application/xml; charset=utf-8',
           },

--- a/src/routes/terms.tsx
+++ b/src/routes/terms.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import LegalDocumentPage from '@/features/legal/components/LegalDocumentPage'
 import { legalPageSearchSchema } from '@/features/legal/lib/legalLinks'
-import { buildLegalPageJsonLd, buildSeoHead } from '@/shared/seo'
+import { buildLegalPageJsonLd, buildSeoHead, SEO_TERMS_KEYWORDS } from '@/shared/seo'
 
 const sections = [
   {
@@ -65,6 +65,7 @@ export const Route = createFileRoute('/terms')({
     title: 'Terms of Service',
     description: 'Review the basic rules for using Pair Research in coursework, research, and related academic collaboration.',
     path: '/terms',
+    keywords: SEO_TERMS_KEYWORDS,
     jsonLd: buildLegalPageJsonLd({
       title: 'Terms of Service',
       path: '/terms',

--- a/src/routes/terms.tsx
+++ b/src/routes/terms.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import LegalDocumentPage from '@/features/legal/components/LegalDocumentPage'
 import { legalPageSearchSchema } from '@/features/legal/lib/legalLinks'
+import { buildLegalPageJsonLd, buildSeoHead } from '@/shared/seo'
 
 const sections = [
   {
@@ -60,8 +61,15 @@ const references = [
 
 export const Route = createFileRoute('/terms')({
   validateSearch: search => legalPageSearchSchema.parse(search),
-  head: () => ({
-    meta: [{ title: 'Terms of Service | Pair Research' }],
+  head: () => buildSeoHead({
+    title: 'Terms of Service',
+    description: 'Review the basic rules for using Pair Research in coursework, research, and related academic collaboration.',
+    path: '/terms',
+    jsonLd: buildLegalPageJsonLd({
+      title: 'Terms of Service',
+      path: '/terms',
+      effectiveDate: '2026-04-14',
+    }),
   }),
   component: TermsPage,
 })

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -25,3 +25,11 @@ export function getTurnstilePublicEnv() {
     siteKey: siteKey.success ? siteKey.data : '',
   }
 }
+
+export function getGooglePublicEnv() {
+  const clientId = z.string().trim().safeParse(import.meta.env.VITE_GOOGLE_CLIENT_ID ?? '')
+
+  return {
+    clientId: clientId.success ? clientId.data : '',
+  }
+}

--- a/src/shared/seo/config.ts
+++ b/src/shared/seo/config.ts
@@ -5,11 +5,52 @@ export const SEO_DEFAULT_TITLE = 'Pair Research'
 export const SEO_DEFAULT_DESCRIPTION
   = 'Pair Research helps academic teams match collaborators, overcome blockers, and coordinate peer support inside research and classroom groups.'
 
+export const SEO_DEFAULT_KEYWORDS = [
+  'Pair Research',
+  'academic collaboration',
+  'research collaboration',
+  'peer support',
+  'group collaboration',
+  'team blockers',
+  'Delta Lab',
+] as const
+
+export const SEO_HOME_KEYWORDS = [
+  'Pair Research',
+  'research collaboration software',
+  'academic collaboration',
+  'peer support',
+  'group collaboration',
+  'collaborative learning',
+  'research group coordination',
+  'Delta Lab',
+] as const
+
+export const SEO_PRIVACY_KEYWORDS = [
+  'Pair Research privacy policy',
+  'Pair Research data privacy',
+  'academic collaboration privacy',
+  'Northwestern University privacy',
+] as const
+
+export const SEO_TERMS_KEYWORDS = [
+  'Pair Research terms',
+  'Pair Research acceptable use',
+  'academic collaboration terms',
+  'research collaboration terms',
+] as const
+
 export const SEO_DEFAULT_IMAGE_PATH = '/images/example.png'
 
-export const SEO_INDEX_ROBOTS = 'index, follow'
+export const SEO_DEFAULT_IMAGE_ALT = 'Pair Research interface showing structured group collaboration features'
 
-export const SEO_NOINDEX_ROBOTS = 'noindex, nofollow'
+export const SEO_DEFAULT_IMAGE_WIDTH = 1776
+
+export const SEO_DEFAULT_IMAGE_HEIGHT = 1170
+
+export const SEO_INDEX_ROBOTS = 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1'
+
+export const SEO_NOINDEX_ROBOTS = 'noindex, nofollow, noarchive'
 
 export const SITEMAP_PUBLIC_ROUTES = [
   {

--- a/src/shared/seo/config.ts
+++ b/src/shared/seo/config.ts
@@ -1,0 +1,33 @@
+export const SEO_SITE_NAME = 'Pair Research'
+
+export const SEO_DEFAULT_TITLE = 'Pair Research'
+
+export const SEO_DEFAULT_DESCRIPTION
+  = 'Pair Research helps academic teams match collaborators, overcome blockers, and coordinate peer support inside research and classroom groups.'
+
+export const SEO_DEFAULT_IMAGE_PATH = '/images/example.png'
+
+export const SEO_INDEX_ROBOTS = 'index, follow'
+
+export const SEO_NOINDEX_ROBOTS = 'noindex, nofollow'
+
+export const SITEMAP_PUBLIC_ROUTES = [
+  {
+    path: '/',
+    lastModified: '2026-05-19',
+    changeFrequency: 'monthly',
+    priority: 1,
+  },
+  {
+    path: '/privacy',
+    lastModified: '2026-04-14',
+    changeFrequency: 'yearly',
+    priority: 0.4,
+  },
+  {
+    path: '/terms',
+    lastModified: '2026-04-14',
+    changeFrequency: 'yearly',
+    priority: 0.4,
+  },
+] as const

--- a/src/shared/seo/head.test.ts
+++ b/src/shared/seo/head.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { SEO_NOINDEX_ROBOTS } from './config'
-import { buildPageTitle, buildSeoHead } from './head'
+import { SEO_DEFAULT_IMAGE_ALT, SEO_NOINDEX_ROBOTS } from './config'
+import { buildPageTitle, buildRootSeoMeta, buildSeoHead } from './head'
 
 describe('seo head helpers', () => {
   it('builds branded page titles without duplicating the default title', () => {
@@ -15,15 +15,32 @@ describe('seo head helpers', () => {
       description: 'Privacy details for Pair Research.',
       path: '/privacy',
       robots: SEO_NOINDEX_ROBOTS,
+      keywords: ['Pair Research privacy', 'academic collaboration privacy'],
       jsonLd: { '@context': 'https://schema.org', '@type': 'WebPage' },
     })
 
     expect(head.links).toContainEqual({ rel: 'canonical', href: 'http://localhost:3000/privacy' })
     expect(head.meta).toContainEqual({ title: 'Privacy Policy | Pair Research' })
     expect(head.meta).toContainEqual({ name: 'description', content: 'Privacy details for Pair Research.' })
-    expect(head.meta).toContainEqual({ name: 'robots', content: 'noindex, nofollow' })
+    expect(head.meta).toContainEqual({ name: 'keywords', content: 'Pair Research privacy, academic collaboration privacy' })
+    expect(head.meta).toContainEqual({ name: 'robots', content: SEO_NOINDEX_ROBOTS })
+    expect(head.meta).toContainEqual({ property: 'og:locale', content: 'en_US' })
     expect(head.meta).toContainEqual({ property: 'og:url', content: 'http://localhost:3000/privacy' })
+    expect(head.meta).toContainEqual({ property: 'og:image:alt', content: SEO_DEFAULT_IMAGE_ALT })
+    expect(head.meta).toContainEqual({ property: 'og:image:width', content: '1776' })
+    expect(head.meta).toContainEqual({ property: 'og:image:height', content: '1170' })
     expect(head.meta).toContainEqual({ name: 'twitter:card', content: 'summary_large_image' })
+    expect(head.meta).toContainEqual({ name: 'twitter:image:alt', content: SEO_DEFAULT_IMAGE_ALT })
     expect(head.meta).toContainEqual({ 'script:ld+json': { '@context': 'https://schema.org', '@type': 'WebPage' } })
+  })
+
+  it('omits blank keyword entries', () => {
+    const head = buildSeoHead({ keywords: ['Pair Research', ' ', 'peer support'] })
+
+    expect(head.meta).toContainEqual({ name: 'keywords', content: 'Pair Research, peer support' })
+  })
+
+  it('adds root application metadata', () => {
+    expect(buildRootSeoMeta()).toContainEqual({ name: 'application-name', content: 'Pair Research' })
   })
 })

--- a/src/shared/seo/head.test.ts
+++ b/src/shared/seo/head.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { SEO_NOINDEX_ROBOTS } from './config'
+import { buildPageTitle, buildSeoHead } from './head'
+
+describe('seo head helpers', () => {
+  it('builds branded page titles without duplicating the default title', () => {
+    expect(buildPageTitle()).toBe('Pair Research')
+    expect(buildPageTitle('Pair Research')).toBe('Pair Research')
+    expect(buildPageTitle('Privacy Policy')).toBe('Privacy Policy | Pair Research')
+  })
+
+  it('builds canonical, Open Graph, Twitter, robots, and JSON-LD tags', () => {
+    const head = buildSeoHead({
+      title: 'Privacy Policy',
+      description: 'Privacy details for Pair Research.',
+      path: '/privacy',
+      robots: SEO_NOINDEX_ROBOTS,
+      jsonLd: { '@context': 'https://schema.org', '@type': 'WebPage' },
+    })
+
+    expect(head.links).toContainEqual({ rel: 'canonical', href: 'http://localhost:3000/privacy' })
+    expect(head.meta).toContainEqual({ title: 'Privacy Policy | Pair Research' })
+    expect(head.meta).toContainEqual({ name: 'description', content: 'Privacy details for Pair Research.' })
+    expect(head.meta).toContainEqual({ name: 'robots', content: 'noindex, nofollow' })
+    expect(head.meta).toContainEqual({ property: 'og:url', content: 'http://localhost:3000/privacy' })
+    expect(head.meta).toContainEqual({ name: 'twitter:card', content: 'summary_large_image' })
+    expect(head.meta).toContainEqual({ 'script:ld+json': { '@context': 'https://schema.org', '@type': 'WebPage' } })
+  })
+})

--- a/src/shared/seo/head.ts
+++ b/src/shared/seo/head.ts
@@ -2,7 +2,11 @@ import type { Graph, Thing, WithContext } from 'schema-dts'
 import { SITE_BASE_URL } from '@/shared/config/constants'
 import {
   SEO_DEFAULT_DESCRIPTION,
+  SEO_DEFAULT_IMAGE_ALT,
+  SEO_DEFAULT_IMAGE_HEIGHT,
   SEO_DEFAULT_IMAGE_PATH,
+  SEO_DEFAULT_IMAGE_WIDTH,
+  SEO_DEFAULT_KEYWORDS,
   SEO_DEFAULT_TITLE,
   SEO_INDEX_ROBOTS,
   SEO_SITE_NAME,
@@ -16,6 +20,10 @@ interface SeoHeadOptions {
   path?: string
   robots?: string
   imagePath?: string
+  imageAlt?: string
+  imageWidth?: number
+  imageHeight?: number
+  keywords?: readonly string[]
   type?: 'website' | 'article'
   jsonLd?: StructuredData
 }
@@ -43,26 +51,37 @@ export function buildSeoHead({
   path = '/',
   robots = SEO_INDEX_ROBOTS,
   imagePath = SEO_DEFAULT_IMAGE_PATH,
+  imageAlt = SEO_DEFAULT_IMAGE_ALT,
+  imageWidth = SEO_DEFAULT_IMAGE_WIDTH,
+  imageHeight = SEO_DEFAULT_IMAGE_HEIGHT,
+  keywords = SEO_DEFAULT_KEYWORDS,
   type = 'website',
   jsonLd,
 }: SeoHeadOptions = {}) {
   const pageTitle = buildPageTitle(title)
   const canonicalUrl = buildAbsoluteUrl(path)
   const imageUrl = buildAbsoluteUrl(imagePath)
+  const keywordContent = keywords.map(keyword => keyword.trim()).filter(Boolean).join(', ')
   const meta: Array<Record<string, unknown>> = [
     { title: pageTitle },
     { name: 'description', content: description },
+    ...(keywordContent === '' ? [] : [{ name: 'keywords', content: keywordContent }]),
     { name: 'robots', content: robots },
     { property: 'og:type', content: type },
+    { property: 'og:locale', content: 'en_US' },
     { property: 'og:site_name', content: SEO_SITE_NAME },
     { property: 'og:title', content: pageTitle },
     { property: 'og:description', content: description },
     { property: 'og:url', content: canonicalUrl },
     { property: 'og:image', content: imageUrl },
+    { property: 'og:image:alt', content: imageAlt },
+    { property: 'og:image:width', content: imageWidth.toString() },
+    { property: 'og:image:height', content: imageHeight.toString() },
     { name: 'twitter:card', content: 'summary_large_image' },
     { name: 'twitter:title', content: pageTitle },
     { name: 'twitter:description', content: description },
     { name: 'twitter:image', content: imageUrl },
+    { name: 'twitter:image:alt', content: imageAlt },
   ]
 
   if (jsonLd !== undefined) {
@@ -81,6 +100,7 @@ export function buildRootSeoMeta() {
   return [
     { charSet: 'utf-8' },
     { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+    { name: 'application-name', content: SEO_SITE_NAME },
     { name: 'theme-color', content: '#ffffff' },
     { name: 'color-scheme', content: 'light' },
     { title: SEO_DEFAULT_TITLE },

--- a/src/shared/seo/head.ts
+++ b/src/shared/seo/head.ts
@@ -1,3 +1,4 @@
+import type { Graph, Thing, WithContext } from 'schema-dts'
 import { SITE_BASE_URL } from '@/shared/config/constants'
 import {
   SEO_DEFAULT_DESCRIPTION,
@@ -7,13 +8,7 @@ import {
   SEO_SITE_NAME,
 } from './config'
 
-type JsonLdValue
-  = string
-    | number
-    | boolean
-    | null
-    | JsonLdValue[]
-    | { [key: string]: JsonLdValue }
+type StructuredData = Graph | WithContext<Thing>
 
 interface SeoHeadOptions {
   title?: string
@@ -22,7 +17,7 @@ interface SeoHeadOptions {
   robots?: string
   imagePath?: string
   type?: 'website' | 'article'
-  jsonLd?: JsonLdValue | JsonLdValue[]
+  jsonLd?: StructuredData
 }
 
 export function buildAbsoluteUrl(path = '/') {

--- a/src/shared/seo/head.ts
+++ b/src/shared/seo/head.ts
@@ -1,0 +1,94 @@
+import { SITE_BASE_URL } from '@/shared/config/constants'
+import {
+  SEO_DEFAULT_DESCRIPTION,
+  SEO_DEFAULT_IMAGE_PATH,
+  SEO_DEFAULT_TITLE,
+  SEO_INDEX_ROBOTS,
+  SEO_SITE_NAME,
+} from './config'
+
+type JsonLdValue
+  = string
+    | number
+    | boolean
+    | null
+    | JsonLdValue[]
+    | { [key: string]: JsonLdValue }
+
+interface SeoHeadOptions {
+  title?: string
+  description?: string
+  path?: string
+  robots?: string
+  imagePath?: string
+  type?: 'website' | 'article'
+  jsonLd?: JsonLdValue | JsonLdValue[]
+}
+
+export function buildAbsoluteUrl(path = '/') {
+  if (SITE_BASE_URL === '') {
+    return path
+  }
+
+  const url = new URL(path, SITE_BASE_URL)
+  return url.toString()
+}
+
+export function buildPageTitle(title?: string) {
+  if (title === undefined || title.trim() === '' || title === SEO_DEFAULT_TITLE) {
+    return SEO_DEFAULT_TITLE
+  }
+
+  return `${title} | ${SEO_SITE_NAME}`
+}
+
+export function buildSeoHead({
+  title,
+  description = SEO_DEFAULT_DESCRIPTION,
+  path = '/',
+  robots = SEO_INDEX_ROBOTS,
+  imagePath = SEO_DEFAULT_IMAGE_PATH,
+  type = 'website',
+  jsonLd,
+}: SeoHeadOptions = {}) {
+  const pageTitle = buildPageTitle(title)
+  const canonicalUrl = buildAbsoluteUrl(path)
+  const imageUrl = buildAbsoluteUrl(imagePath)
+  const meta: Array<Record<string, unknown>> = [
+    { title: pageTitle },
+    { name: 'description', content: description },
+    { name: 'robots', content: robots },
+    { property: 'og:type', content: type },
+    { property: 'og:site_name', content: SEO_SITE_NAME },
+    { property: 'og:title', content: pageTitle },
+    { property: 'og:description', content: description },
+    { property: 'og:url', content: canonicalUrl },
+    { property: 'og:image', content: imageUrl },
+    { name: 'twitter:card', content: 'summary_large_image' },
+    { name: 'twitter:title', content: pageTitle },
+    { name: 'twitter:description', content: description },
+    { name: 'twitter:image', content: imageUrl },
+  ]
+
+  if (jsonLd !== undefined) {
+    meta.push({ 'script:ld+json': jsonLd })
+  }
+
+  return {
+    meta,
+    links: [
+      { rel: 'canonical', href: canonicalUrl },
+    ],
+  }
+}
+
+export function buildRootSeoMeta() {
+  return [
+    { charSet: 'utf-8' },
+    { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+    { name: 'theme-color', content: '#ffffff' },
+    { name: 'color-scheme', content: 'light' },
+    { title: SEO_DEFAULT_TITLE },
+    { name: 'description', content: SEO_DEFAULT_DESCRIPTION },
+  ]
+}

--- a/src/shared/seo/index.ts
+++ b/src/shared/seo/index.ts
@@ -1,0 +1,5 @@
+export * from './config'
+export * from './head'
+export * from './robots'
+export * from './sitemap'
+export * from './structuredData'

--- a/src/shared/seo/robots.test.ts
+++ b/src/shared/seo/robots.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { buildRobotsTxt } from './robots'
+
+describe('robots.txt helper', () => {
+  it('blocks all crawling when indexing is disabled', () => {
+    expect(buildRobotsTxt({
+      siteBaseUrl: 'https://pairresearch.io',
+      indexingEnabled: false,
+    })).toBe([
+      'User-agent: *',
+      'Disallow: /',
+      '',
+      'Sitemap: https://pairresearch.io/sitemap.xml',
+    ].join('\n'))
+  })
+
+  it('allows public routes and blocks auth/private app routes when indexing is enabled', () => {
+    const robots = buildRobotsTxt({
+      siteBaseUrl: 'https://pairresearch.io',
+      indexingEnabled: true,
+    })
+
+    expect(robots).toContain('Allow: /$')
+    expect(robots).toContain('Disallow: /groups')
+    expect(robots).toContain('Disallow: /login')
+    expect(robots).toContain('Sitemap: https://pairresearch.io/sitemap.xml')
+  })
+})

--- a/src/shared/seo/robots.ts
+++ b/src/shared/seo/robots.ts
@@ -1,0 +1,36 @@
+import { SITE_BASE_URL } from '@/shared/config/constants'
+
+const PRIVATE_ROBOT_PATHS = [
+  '/account',
+  '/auth',
+  '/forgot-password',
+  '/groups',
+  '/login',
+  '/reset-password',
+  '/signup',
+] as const
+
+export function buildRobotsTxt({
+  siteBaseUrl = SITE_BASE_URL,
+  indexingEnabled = import.meta.env.PROD && SITE_BASE_URL !== '',
+}: {
+  siteBaseUrl?: string
+  indexingEnabled?: boolean
+} = {}) {
+  if (!indexingEnabled) {
+    return [
+      'User-agent: *',
+      'Disallow: /',
+      '',
+      siteBaseUrl === '' ? undefined : `Sitemap: ${siteBaseUrl}/sitemap.xml`,
+    ].filter(line => line !== undefined).join('\n')
+  }
+
+  return [
+    'User-agent: *',
+    'Allow: /$',
+    ...PRIVATE_ROBOT_PATHS.map(path => `Disallow: ${path}`),
+    '',
+    `Sitemap: ${siteBaseUrl}/sitemap.xml`,
+  ].join('\n')
+}

--- a/src/shared/seo/sitemap.test.ts
+++ b/src/shared/seo/sitemap.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { buildSitemapXml } from './sitemap'
+
+describe('sitemap helper', () => {
+  it('includes only canonical public indexable routes', () => {
+    const sitemap = buildSitemapXml('https://pairresearch.io')
+
+    expect(sitemap).toContain('<loc>https://pairresearch.io/</loc>')
+    expect(sitemap).toContain('<loc>https://pairresearch.io/privacy</loc>')
+    expect(sitemap).toContain('<loc>https://pairresearch.io/terms</loc>')
+    expect(sitemap).not.toContain('/login')
+    expect(sitemap).not.toContain('/groups')
+  })
+})

--- a/src/shared/seo/sitemap.ts
+++ b/src/shared/seo/sitemap.ts
@@ -1,0 +1,37 @@
+import { SITE_BASE_URL } from '@/shared/config/constants'
+import { SITEMAP_PUBLIC_ROUTES } from './config'
+
+function escapeXml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('\'', '&apos;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+}
+
+export function buildSitemapXml(siteBaseUrl = SITE_BASE_URL) {
+  if (siteBaseUrl === '') {
+    throw new Error('SITE_BASE_URL is not defined')
+  }
+
+  const urls = SITEMAP_PUBLIC_ROUTES.map((route) => {
+    const loc = new URL(route.path, siteBaseUrl).toString()
+
+    return [
+      '  <url>',
+      `    <loc>${escapeXml(loc)}</loc>`,
+      `    <lastmod>${route.lastModified}</lastmod>`,
+      `    <changefreq>${route.changeFrequency}</changefreq>`,
+      `    <priority>${route.priority.toFixed(1)}</priority>`,
+      '  </url>',
+    ].join('\n')
+  }).join('\n')
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    urls,
+    '</urlset>',
+  ].join('\n')
+}

--- a/src/shared/seo/structuredData.test.ts
+++ b/src/shared/seo/structuredData.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { buildPairResearchJsonLd } from './structuredData'
+
+describe('structured data helpers', () => {
+  it('describes Pair Research as a website and web application without commercial offer fields', () => {
+    const jsonLd = buildPairResearchJsonLd()
+
+    expect(jsonLd['@context']).toBe('https://schema.org')
+    const nodeTypes = jsonLd['@graph'].map((node) => {
+      if (typeof node === 'string') {
+        return node
+      }
+
+      return node['@type']
+    })
+
+    expect(nodeTypes).toEqual([
+      'WebSite',
+      'WebApplication',
+      'ResearchOrganization',
+      'SoftwareSourceCode',
+    ])
+
+    const serialized = JSON.stringify(jsonLd)
+    expect(serialized).not.toContain('sameAs')
+    expect(serialized).not.toContain('offers')
+    expect(serialized).toContain('https://github.com/NUDelta/pair-research')
+  })
+})

--- a/src/shared/seo/structuredData.ts
+++ b/src/shared/seo/structuredData.ts
@@ -1,0 +1,69 @@
+import { buildAbsoluteUrl } from './head'
+
+export function buildOrganizationJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    'name': 'Pair Research',
+    'url': buildAbsoluteUrl('/'),
+    'logo': buildAbsoluteUrl('/images/logo.webp'),
+    'sameAs': [
+      'https://delta.northwestern.edu/',
+    ],
+  }
+}
+
+export function buildWebSiteJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    'name': 'Pair Research',
+    'url': buildAbsoluteUrl('/'),
+    'description': 'A collaboration app for structured peer support in research and classroom groups.',
+    'publisher': {
+      '@type': 'Organization',
+      'name': 'Delta Lab',
+      'url': 'https://delta.northwestern.edu/',
+    },
+  }
+}
+
+export function buildSoftwareApplicationJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    'name': 'Pair Research',
+    'applicationCategory': 'EducationalApplication',
+    'operatingSystem': 'Web',
+    'url': buildAbsoluteUrl('/'),
+    'description': 'Pair Research matches group members so they can help each other move past blockers.',
+    'offers': {
+      '@type': 'Offer',
+      'price': '0',
+      'priceCurrency': 'USD',
+    },
+  }
+}
+
+export function buildLegalPageJsonLd({
+  title,
+  path,
+  effectiveDate,
+}: {
+  title: string
+  path: string
+  effectiveDate: string
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    'name': title,
+    'url': buildAbsoluteUrl(path),
+    'dateModified': effectiveDate,
+    'isPartOf': {
+      '@type': 'WebSite',
+      'name': 'Pair Research',
+      'url': buildAbsoluteUrl('/'),
+    },
+  }
+}

--- a/src/shared/seo/structuredData.ts
+++ b/src/shared/seo/structuredData.ts
@@ -1,47 +1,76 @@
+import type { Graph, WebPage, WebSite, WithContext } from 'schema-dts'
 import { buildAbsoluteUrl } from './head'
 
-export function buildOrganizationJsonLd() {
-  return {
-    '@context': 'https://schema.org',
-    '@type': 'Organization',
-    'name': 'Pair Research',
-    'url': buildAbsoluteUrl('/'),
-    'logo': buildAbsoluteUrl('/images/logo.webp'),
-    'sameAs': [
-      'https://delta.northwestern.edu/',
-    ],
-  }
-}
+const GITHUB_REPOSITORY_URL = 'https://github.com/NUDelta/pair-research'
 
-export function buildWebSiteJsonLd() {
+export function buildWebSiteJsonLd(): WithContext<WebSite> {
   return {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
+    '@id': buildAbsoluteUrl('/#website'),
     'name': 'Pair Research',
     'url': buildAbsoluteUrl('/'),
     'description': 'A collaboration app for structured peer support in research and classroom groups.',
     'publisher': {
-      '@type': 'Organization',
-      'name': 'Delta Lab',
-      'url': 'https://delta.northwestern.edu/',
+      '@id': buildAbsoluteUrl('/#delta-lab'),
     },
   }
 }
 
-export function buildSoftwareApplicationJsonLd() {
+export function buildPairResearchJsonLd(): Graph {
   return {
     '@context': 'https://schema.org',
-    '@type': 'SoftwareApplication',
-    'name': 'Pair Research',
-    'applicationCategory': 'EducationalApplication',
-    'operatingSystem': 'Web',
-    'url': buildAbsoluteUrl('/'),
-    'description': 'Pair Research matches group members so they can help each other move past blockers.',
-    'offers': {
-      '@type': 'Offer',
-      'price': '0',
-      'priceCurrency': 'USD',
-    },
+    '@graph': [
+      {
+        '@type': 'WebSite',
+        '@id': buildAbsoluteUrl('/#website'),
+        'name': 'Pair Research',
+        'url': buildAbsoluteUrl('/'),
+        'description': 'A collaboration app for structured peer support in research and classroom groups.',
+        'publisher': {
+          '@id': buildAbsoluteUrl('/#delta-lab'),
+        },
+      },
+      {
+        '@type': 'WebApplication',
+        '@id': buildAbsoluteUrl('/#app'),
+        'name': 'Pair Research',
+        'applicationCategory': 'EducationalApplication',
+        'browserRequirements': 'Requires a modern web browser with JavaScript enabled.',
+        'operatingSystem': 'Web',
+        'url': buildAbsoluteUrl('/'),
+        'description': 'Pair Research matches group members so they can help each other move past blockers.',
+        'creator': {
+          '@id': buildAbsoluteUrl('/#delta-lab'),
+        },
+        'maintainer': {
+          '@id': buildAbsoluteUrl('/#delta-lab'),
+        },
+        'isBasedOn': {
+          '@id': buildAbsoluteUrl('/#source-code'),
+        },
+      },
+      {
+        '@type': 'ResearchOrganization',
+        '@id': buildAbsoluteUrl('/#delta-lab'),
+        'name': 'Delta Lab',
+        'url': 'https://delta.northwestern.edu/',
+      },
+      {
+        '@type': 'SoftwareSourceCode',
+        '@id': buildAbsoluteUrl('/#source-code'),
+        'name': 'Pair Research source code',
+        'codeRepository': GITHUB_REPOSITORY_URL,
+        'programmingLanguage': 'TypeScript',
+        'runtimePlatform': 'Web',
+        'targetProduct': {
+          '@id': buildAbsoluteUrl('/#app'),
+        },
+        'creator': {
+          '@id': buildAbsoluteUrl('/#delta-lab'),
+        },
+      },
+    ],
   }
 }
 
@@ -53,7 +82,7 @@ export function buildLegalPageJsonLd({
   title: string
   path: string
   effectiveDate: string
-}) {
+}): WithContext<WebPage> {
   return {
     '@context': 'https://schema.org',
     '@type': 'WebPage',

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -37,3 +37,29 @@ interface CurrentUserActivePair {
   helperFullName: string | null // The full name of the helper
   helperAvatarUrl: string | null // The avatar url of the helper
 }
+
+interface GoogleOneTapCredentialResponse {
+  credential?: string
+}
+
+interface GoogleOneTapInitializeOptions {
+  client_id: string
+  callback: (response: GoogleOneTapCredentialResponse) => void | Promise<void>
+  cancel_on_tap_outside?: boolean
+  context?: 'signin' | 'signup' | 'use'
+  itp_support?: boolean
+}
+
+interface Window {
+  google?: {
+    accounts: {
+      id: {
+        initialize: (options: GoogleOneTapInitializeOptions) => void
+        prompt: () => void
+        cancel: () => void
+      }
+    }
+  }
+}
+
+declare const google: Window['google']


### PR DESCRIPTION
## ✨ Features Updates

### 📌 Description

This PR adds shared SEO metadata coverage for Pair Research and introduces Google One Tap sign-in support.

The SEO changes replace route-local metadata with shared helpers for canonical URLs, Open Graph/Twitter metadata, robots directives, sitemap generation, and JSON-LD structured data. The auth changes reuse the existing Google OAuth callback path while adding an optional One Tap flow gated by `VITE_GOOGLE_CLIENT_ID`.

### 🔍 Feature Changes

- [x] New component or page
- [x] UI/UX improvement
- [x] Other: SEO metadata, robots.txt, sitemap.xml, structured data, and optional Google One Tap sign-in

### 🔄 Refactor Changes

- [x] Improve maintainability
- [x] Remove unnecessary code
- [x] Other: centralize shared SEO helpers under `src/shared/seo`

### 🛠 Bug Fixes

- [x] Fixed issue: public pages now expose indexable metadata while auth/private routes keep noindex robots directives.
- [x] Other: Google OAuth redirect URL construction is centralized and sanitized.

### ✅ Checklist

1. Feature Updates:

- [x] Code follows project coding style.
- [x] Tested in the TanStack Start + Vite environment.
- [x] Relevant documentation is updated.

2. Bug Fixes:

- [x] Fix does not introduce new issues.
- [x] Added necessary tests.

3. Code Refactor:

- [x] No breaking changes introduced.

4. Dependency Updates:

- [x] Verified functionality after update.

### 📜 Dependency Changes

| Dependency Name | Old Version | New Version | Reason |
| --- | --- | --- | --- |
| schema-dts | Not present | 2.0.0 | Type structured JSON-LD helpers |

### 💬 Additional Notes

- Google One Tap is optional. If `VITE_GOOGLE_CLIENT_ID` is not configured, the component exits without loading the Google Identity script.
- Preview verification confirmed metadata output for `/`, `/login`, `/privacy`, `/terms`, `/robots.txt`, and `/sitemap.xml`.
- Full e2e auth setup/authenticated tests were skipped by the existing Playwright project configuration because credentials were not provided.

### ✅ Validation

- `pnpm exec vitest run src/shared/seo src/features/auth/lib/googleAuth.test.ts src/features/auth/lib/googleOneTap.test.ts`
- `pnpm run lint:ci`
- `pnpm run build`
- Push hook: `eslint . --fix`
- Push hook: `pnpm run test:unit && pnpm run test:e2e`
- Push hook: `vite build`
